### PR TITLE
Add Cambridge-az centre

### DIFF
--- a/crawler/config/defaults.py
+++ b/crawler/config/defaults.py
@@ -4,6 +4,28 @@ from crawler.constants import FIELD_RNA_ID
 DIR_DOWNLOADED_DATA = "data/"
 
 # centre details
+# This information will also be persisted in the mongo database
+# Field information:
+# barcode_field: The header of the column containing barcode/well information
+# barcode_regex: Regular expression for extracting barcodes and well co-ordinates
+#                from barcode_field
+# merge_required: True for centres delivering incremental updates. Indicates that
+#                 the individual csv files need to be merged into a single master
+#                 file. False indicates that the latest CSV will contain a full
+#                 dump.
+# name: The name of the centre
+# prefix: The COG-UK prefix. Used for naming the download directory, but also
+#         stored in the database for later use by other processes.
+#        ie. lighthouse and barcoda
+# merge_start_date: Used for centres which switch from full dumps to incremental
+#                   updates. Files before this date will be ignored. Please ensure
+#                   that at least one complete dump is included in the timeframe.
+# sftp_file_regex: Regex to identify files to load from the sftp server
+# sftp_master_file_regex: Regexp to identify the master file for incremental updates
+# sftp_root_read: directory on sftp from which to load csv files.
+# sftp_root_write: directory on sftp in which to upload master files
+# file_names_to_ignore: array of files to exclude from processing, such as those
+#                       containing invalid headers
 CENTRES = [
     {
         "barcode_field": FIELD_RNA_ID,

--- a/crawler/config/defaults.py
+++ b/crawler/config/defaults.py
@@ -51,7 +51,7 @@ CENTRES = [
         "barcode_regex": r"^(.*)_([A-Z]\d\d)$",
         "merge_required": True,
         "name": "Cambridge-az",
-        "prefix": "CB",
+        "prefix": "CBAZ",
         "sftp_file_regex": r"^CB_sanger_report_(\d{6}_\d{4})\.csv$",
         "sftp_master_file_regex": r"^CB_sanger_report_(\d{6}_\d{4})_master\.csv$",
         "sftp_root_read": "project-heron_cambridge-az",

--- a/crawler/config/defaults.py
+++ b/crawler/config/defaults.py
@@ -46,6 +46,18 @@ CENTRES = [
         "sftp_root_write": "/project-heron_glasgow/psd-lims",
         "file_names_to_ignore": [],
     },
+    {
+        "barcode_field": FIELD_RNA_ID,
+        "barcode_regex": r"^(.*)_([A-Z]\d\d)$",
+        "merge_required": True,
+        "name": "Cambridge-az",
+        "prefix": "CB",
+        "sftp_file_regex": r"^CB_sanger_report_(\d{6}_\d{4})\.csv$",
+        "sftp_master_file_regex": r"^CB_sanger_report_(\d{6}_\d{4})_master\.csv$",
+        "sftp_root_read": "project-heron_cambridge-az",
+        "sftp_root_write": "/project-heron_cambridge-az/psd-lims",
+        "file_names_to_ignore": [],
+    },
 ]
 
 # mongo details

--- a/crawler/config/test.py
+++ b/crawler/config/test.py
@@ -50,7 +50,7 @@ CENTRES = [
         "barcode_regex": r"^(.*)_([A-Z]\d\d)$",
         "merge_required": True,
         "name": "Cambridge-az",
-        "prefix": "CB",
+        "prefix": "CBAZ",
         "sftp_file_regex": r"^CB_sanger_report_(\d{6}_\d{4})\.csv$",
         "sftp_master_file_regex": r"^CB_sanger_report_(\d{6}_\d{4})_master\.csv$",
         "sftp_root_read": "project-heron_cambridge-az",

--- a/crawler/config/test.py
+++ b/crawler/config/test.py
@@ -44,7 +44,19 @@ CENTRES = [
         "sftp_root_read": "tests/files",
         "sftp_root_write": "tests/files/write",
         "file_names_to_ignore": ["TEST_sanger_report_200518_2205.csv"]
-    }
+    },
+    {
+        "barcode_field": FIELD_RNA_ID,
+        "barcode_regex": r"^(.*)_([A-Z]\d\d)$",
+        "merge_required": True,
+        "name": "Cambridge-az",
+        "prefix": "CB",
+        "sftp_file_regex": r"^CB_sanger_report_(\d{6}_\d{4})\.csv$",
+        "sftp_master_file_regex": r"^CB_sanger_report_(\d{6}_\d{4})_master\.csv$",
+        "sftp_root_read": "project-heron_cambridge-az",
+        "sftp_root_write": "/project-heron_cambridge-az/psd-lims",
+        "file_names_to_ignore": [],
+    },
 ]
 
 # SFTP details


### PR DESCRIPTION
Adds the Cambridge-az centre to the defaults.py and test.py configuration.
Uses incremental update.

Closes #50

Changes proposed in this pull request:

* Adds Cambridge-az to centers
