### PR TITLE
GPL575 - Bugfix timestamp does not change 2nd time job is run

### DIFF
--- a/crawler/main.py
+++ b/crawler/main.py
@@ -39,8 +39,9 @@ from crawler.helpers import (
 logger = logging.getLogger(__name__)
 
 
-def run(sftp: bool, settings_module: str = "", timestamp: str = current_time()) -> None:
+def run(sftp: bool, settings_module: str = "", timestamp: str = None) -> None:
     try:
+        timestamp = timestamp or current_time()
         start = time.time()
         config, settings_module = get_config(settings_module)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,6 +59,7 @@ def test_run(mongo_database):
     (_, _, files) = next(os.walk("tmp/files"))
     assert 0 == len(files)
 
+
 # If we have multiple runs, the older runs are archived with a timestamps
 def test_repeat_run(mongo_database):
     _, mongo_database = mongo_database
@@ -93,7 +94,23 @@ def test_repeat_run(mongo_database):
     assert imports_collection.count_documents({}) == NUMBER_CENTRES * 2
 
 
-# If we have multiple runs, the older runs are archived with a timestamps
+# If we run it without timestamp, the process dont fail
+def test_job_run(mongo_database):
+    _, mongo_database = mongo_database
+    _ = shutil.copytree("tests/files", "tmp/files", dirs_exist_ok=True)
+    run(False, "crawler.config.integration")
+    run(False, "crawler.config.integration")
+
+    centres_collection = get_mongo_collection(mongo_database, COLLECTION_CENTRES)
+    imports_collection = get_mongo_collection(mongo_database, COLLECTION_IMPORTS)
+    samples_collection = get_mongo_collection(mongo_database, COLLECTION_SAMPLES)
+
+    # We still have 4 test centers
+    assert centres_collection.count_documents({}) == NUMBER_CENTRES
+    # We don't get extra samples
+    assert samples_collection.count_documents({}) == NUMBER_VALID_SAMPLES
+    # We get additional imports
+    assert imports_collection.count_documents({}) == NUMBER_CENTRES * 2
 
 
 def test_error_run(mongo_database):


### PR DESCRIPTION
When rerunning the job the second time, the timestamp is not
generated again, which it causes a naming clash on the destination
samples collection to create.
Instead, we'll obtain the new timestamp every run unless provided
as argument.

Closes GPL575

