### PR TITLE
Gpl 806 add all negative plates in add to dart migration

### DIFF
--- a/migrations/helpers/dart_samples_update_helper.py
+++ b/migrations/helpers/dart_samples_update_helper.py
@@ -48,7 +48,8 @@ from pymongo.operations import UpdateOne
 # 4. update samples in mongo updated in either of the above two steps (would expect the same set of samples from both
 #       steps)
 # 5. update the MLWH (should be an idempotent operation)
-# 6. add all the plates of the positive samples we've selected in step 1 above, to DART
+# 6. add all the plates with non-cherrypicked samples (determined in step 2) to DART, as well as any positive samples
+#       in these plates
 
 
 logger = logging.getLogger(__name__)
@@ -140,7 +141,8 @@ def migrate_all_dbs(config, s_start_datetime: str = "", s_end_datetime: str = ""
                 # 5. update the MLWH (should be an idempotent operation)
                 run_mysql_executemany_query(mlwh_conn, SQL_MLWH_MULTIPLE_INSERT, mongo_docs_for_sql)
 
-            # 6. add all the plates of the positive samples we've selected in step 1 above, to DART
+            # 6. add all the plates with non-cherrypicked samples (determined in step 2) to DART, as well as any
+            #       positive samples in these plates
             update_dart_fields(config, samples)
         else:
             logger.info("No documents found for this timestamp range, nothing to insert or update in MLWH or DART")

--- a/migrations/helpers/dart_samples_update_helper.py
+++ b/migrations/helpers/dart_samples_update_helper.py
@@ -13,7 +13,6 @@ from crawler.constants import (
     FIELD_LH_SOURCE_PLATE_UUID,
     FIELD_MONGODB_ID,
     FIELD_PLATE_BARCODE,
-    FIELD_RESULT,
     FIELD_ROOT_SAMPLE_ID,
     FIELD_UPDATED_AT,
     MONGO_DATETIME_FORMAT,
@@ -150,9 +149,7 @@ def migrate_all_dbs(config, s_start_datetime: str = "", s_end_datetime: str = ""
         logger.exception(e)
 
 
-def get_samples(
-    samples_collection: Collection, start_datetime: datetime, end_datetime: datetime
-) -> List[Sample]:
+def get_samples(samples_collection: Collection, start_datetime: datetime, end_datetime: datetime) -> List[Sample]:
     logger.debug(f"Selecting positive samples between {start_datetime} and {end_datetime}")
 
     match = {

--- a/migrations/helpers/dart_samples_update_helper.py
+++ b/migrations/helpers/dart_samples_update_helper.py
@@ -43,7 +43,7 @@ from pymongo.operations import UpdateOne
 # * Do not add samples to DART which have already been cherry-picked
 # * Only add positive samples to DART
 ####
-# 1. get samples from mongo between these time ranges that are positive
+# 1. get samples from mongo between these time ranges
 # 2. of these, find which have been cherry-picked and remove them from the list
 # 3. add the UUID fields if not present
 # 4. update samples in mongo updated in either of the above two steps (would expect the same set of samples from both
@@ -86,8 +86,8 @@ def migrate_all_dbs(config, s_start_datetime: str = "", s_end_datetime: str = ""
 
             samples_collection = get_mongo_collection(mongo_db, COLLECTION_SAMPLES)
 
-            # 1. get samples from mongo between these time ranges that are positive
-            samples = get_positive_samples(samples_collection, start_datetime, end_datetime)
+            # 1. get samples from mongo between these time ranges
+            samples = get_samples(samples_collection, start_datetime, end_datetime)
 
             if not samples:
                 logger.info("No samples in this time range.")
@@ -150,16 +150,15 @@ def migrate_all_dbs(config, s_start_datetime: str = "", s_end_datetime: str = ""
         logger.exception(e)
 
 
-def get_positive_samples(
+def get_samples(
     samples_collection: Collection, start_datetime: datetime, end_datetime: datetime
 ) -> List[Sample]:
     logger.debug(f"Selecting positive samples between {start_datetime} and {end_datetime}")
 
     match = {
         "$match": {
-            # 1. First filter by the start and end dates
+            # Filter by the start and end dates
             FIELD_CREATED_AT: {"$gte": start_datetime, "$lte": end_datetime},
-            FIELD_RESULT: {"$regex": "^positive", "$options": "i"},
         }
     }
 

--- a/migrations/helpers/update_filtered_positives_helper.py
+++ b/migrations/helpers/update_filtered_positives_helper.py
@@ -243,17 +243,18 @@ def update_dart_fields(config: ModuleType, samples: List[Sample]) -> bool:
                 )
                 if plate_state == DART_STATE_PENDING:
                     for sample in samples_in_plate:
-                        well_index = get_dart_well_index(sample.get(FIELD_COORDINATE, None))
-                        if well_index is not None:
-                            well_props = map_mongo_doc_to_dart_well_props(sample)
-                            set_dart_well_properties(
-                                cursor, plate_barcode, well_props, well_index  # type:ignore
-                            )
-                        else:
-                            raise ValueError(
-                                "Unable to determine DART well index for sample "
-                                f"{sample[FIELD_ROOT_SAMPLE_ID]} in plate {plate_barcode}"
-                            )
+                        if sample[FIELD_RESULT] == POSITIVE_RESULT_VALUE:
+                            well_index = get_dart_well_index(sample.get(FIELD_COORDINATE, None))
+                            if well_index is not None:
+                                well_props = map_mongo_doc_to_dart_well_props(sample)
+                                set_dart_well_properties(
+                                    cursor, plate_barcode, well_props, well_index  # type:ignore
+                                )
+                            else:
+                                raise ValueError(
+                                    "Unable to determine DART well index for sample "
+                                    f"{sample[FIELD_ROOT_SAMPLE_ID]} in plate {plate_barcode}"
+                                )
                 cursor.commit()
                 dart_updated_successfully &= True
             except Exception as e:

--- a/tests/migrations/helpers/test_dart_samples_update_helper.py
+++ b/tests/migrations/helpers/test_dart_samples_update_helper.py
@@ -21,7 +21,7 @@ from crawler.constants import (
 )
 from migrations.helpers.dart_samples_update_helper import (
     add_sample_uuid_field,
-    get_positive_samples,
+    get_samples,
     migrate_all_dbs,
     new_mongo_source_plate,
     samples_updated_with_source_plate_uuids,
@@ -99,7 +99,7 @@ def generate_example_samples(range, start_datetime):
 # ----- helper method tests -----
 
 
-def test_get_positive_samples(mongo_database):
+def test_get_samples(mongo_database):
     _, mongo_db = mongo_database
 
     start_datetime = datetime(year=2020, month=5, day=10, hour=15, minute=10)
@@ -110,8 +110,8 @@ def test_get_positive_samples(mongo_database):
 
     assert mongo_db.samples.count_documents({}) == 8
 
-    # although 6 samples would be created, test that we are selecting only a subset using dates
-    assert len(get_positive_samples(mongo_db.samples, start_datetime, (start_datetime + timedelta(days=2)))) == 4
+    # although 6 samples would be created, test that we are selecting only a subset using dates, including the -ve one
+    assert len(get_samples(mongo_db.samples, start_datetime, (start_datetime + timedelta(days=2)))) == 5
 
 
 def test_add_sample_uuid_field():
@@ -346,7 +346,7 @@ def test_migrate_all_dbs_with_cherry_picked_samples_mocked(
 
             migrate_all_dbs(config, start_datetime.strftime("%y%m%d_%H%M"), end_datetime.strftime("%y%m%d_%H%M"))
 
-            samples = get_positive_samples(mongo_db.samples, start_datetime, end_datetime)
+            samples = get_samples(mongo_db.samples, start_datetime, end_datetime)
 
             mock_remove_cherrypicked_samples.assert_called_once_with(
                 samples, [[cherry_picked_sample[FIELD_ROOT_SAMPLE_ID][0], cherry_picked_sample[FIELD_PLATE_BARCODE][0]]]

--- a/tests/migrations/helpers/test_update_filtered_positives_helper.py
+++ b/tests/migrations/helpers/test_update_filtered_positives_helper.py
@@ -602,7 +602,7 @@ def test_update_dart_fields_returns_true_single_new_plate_multiple_wells(config,
 
                     pos_samples = samples[:-1]
                     num_pos_samples = len(pos_samples)
-                    assert mock_get_well_index.call_count == num_pos_samples 
+                    assert mock_get_well_index.call_count == num_pos_samples
                     assert mock_map.call_count == num_pos_samples
                     assert mock_set_well_props.call_count == num_pos_samples
                     for sample in pos_samples:


### PR DESCRIPTION
Closes #202 

Changes proposed in this pull request:

* Ensure we add all-negative plates to DART during the add-to-DART migration
* As a result, migration is also updated to add UUID fields to all samples, not just Result=Positive ones. Is this an issue? I don't think it is
