### PR TITLE
Fix filtered positive rule change migration

### DIFF
--- a/migrations/helpers/update_filtered_positives_helper.py
+++ b/migrations/helpers/update_filtered_positives_helper.py
@@ -109,7 +109,9 @@ def remove_cherrypicked_samples(config: ModuleType, samples: List[Sample]) -> Li
     root_sample_ids, plate_barcodes = extract_required_cp_info(samples)
     cp_samples_df = get_cherrypicked_samples(config, list(root_sample_ids), list(plate_barcodes))
 
-    if cp_samples_df is not None and not cp_samples_df.empty:
+    if cp_samples_df is None:
+        raise Exception("Unable to determine cherry-picked samples - potentially error connecting to MySQL")
+    elif not cp_samples_df.empty:
         cp_samples = cp_samples_df[[FIELD_ROOT_SAMPLE_ID, FIELD_PLATE_BARCODE]].to_numpy().tolist()
         return remove_cp_samples(samples, cp_samples)
     else:

--- a/tests/migrations/helpers/test_update_filtered_positives_helper.py
+++ b/tests/migrations/helpers/test_update_filtered_positives_helper.py
@@ -155,8 +155,8 @@ def test_remove_cherrypicked_samples_throws_for_error_getting_cherrypicked_sampl
 
 def test_remove_cherrypicked_samples_returns_input_samples_with_none_cp_samples_df(config, testing_samples):
     with patch("migrations.helpers.update_filtered_positives_helper.get_cherrypicked_samples", return_value=None):
-        result = remove_cherrypicked_samples(config, testing_samples)
-        assert result == testing_samples
+        with pytest.raises(Exception):
+            remove_cherrypicked_samples(config, testing_samples)
 
 
 def test_remove_cherrypicked_samples_returns_input_samples_with_empty_cp_samples_df(config, testing_samples):


### PR DESCRIPTION
As with the other migrations, update the filtered positive rule change migration to raise if the cherrypicked samples data frame is None
