### PR TITLE
Specify buster as the base image for Python 3.8 Slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use alpine for a smaller image size and install only the required packages
-FROM python:3.8-slim
+FROM python:3.8-slim-buster
 
 # > Setting PYTHONUNBUFFERED to a non empty value ensures that the python output is sent straight to
 # > terminal (e.g. your container log) without being first buffered and that you can see the output


### PR DESCRIPTION
The Python 3.8 slim image in Docker has recently been changed to base off Debian v11 (Bullseye) which cannot install msodbcsql17 from apt-get because of a failed dependency on multiarch-support.  The previous installs were using Debian v10 (Buster).  Changing the base image here forces the old base image behaviour where we can install msodbcsql17 successfully.

https://hub.docker.com/_/python
