### PR TITLE
DPL-203: Fix HTTPS communication with Baracoda

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ The following tools are required for development:
   recommended.  Follow the instructions under the Docker section of this
   document to bringing up the dependencies and ensure these are available.
 
+### Additional Dependencies
+
+If you intend to test/develop/use the test data generation functionality of
+Crawler at the `/v1/cherrypick-test-data` endpoint, you will also need to be
+running a local instance of [Baracoda](https://github.com/sanger/baracoda).  The
+default port of Baracoda is 8000, but if you need to use a different port,
+change the port specified for Baracoda in the `crawler/config/defaults.py` file
+in this repository.
+
 ## Getting Started
 
 ### Configuring Environment

--- a/crawler/config/defaults.py
+++ b/crawler/config/defaults.py
@@ -41,7 +41,7 @@ ROOT_PASSWORD = os.environ.get("ROOT_PASSWORD", "")
 ###
 # Baracoda
 ###
-BARACODA_BASE_URL = "http://uat.baracoda.psd.sanger.ac.uk"
+BARACODA_BASE_URL = "https://uat.baracoda.psd.sanger.ac.uk"
 
 ###
 # mongo details

--- a/crawler/config/defaults.py
+++ b/crawler/config/defaults.py
@@ -41,7 +41,7 @@ ROOT_PASSWORD = os.environ.get("ROOT_PASSWORD", "")
 ###
 # Baracoda
 ###
-BARACODA_BASE_URL = "https://uat.baracoda.psd.sanger.ac.uk"
+BARACODA_BASE_URL = f"http://{LOCALHOST}:8000"
 BARACODA_RETRY_ATTEMPTS = 3
 
 ###

--- a/crawler/constants.py
+++ b/crawler/constants.py
@@ -116,6 +116,9 @@ TEST_DATA_ERROR_NUMBER_OF_PLATES: Final[str] = "Number of plates to generate mus
 TEST_DATA_ERROR_NUMBER_OF_POS_SAMPLES: Final[
     str
 ] = "One or more plates expected fewer than 0 or more than 96 positive samples."
+TEST_DATA_ERROR_BARACODA_COG_BARCODES: Final[str] = "Unable to create COG barcodes"
+TEST_DATA_ERROR_BARACODA_CONNECTION: Final[str] = "Unable to access baracoda"
+TEST_DATA_ERROR_BARACODA_UNKNOWN: Final[str] = "Unknown error accessing baracoda"
 
 
 ##

--- a/crawler/helpers/cherrypicker_test_data.py
+++ b/crawler/helpers/cherrypicker_test_data.py
@@ -15,7 +15,11 @@ from crawler.constants import (
     FIELD_RNA_PCR_ID,
     FIELD_ROOT_SAMPLE_ID,
     FIELD_VIRAL_PREP_ID,
+    TEST_DATA_ERROR_BARACODA_COG_BARCODES,
+    TEST_DATA_ERROR_BARACODA_CONNECTION,
+    TEST_DATA_ERROR_BARACODA_UNKNOWN,
 )
+from crawler.helpers.exceptions import CherrypickerDataError
 from crawler.types import Config
 
 logger = logging.getLogger(__name__)
@@ -62,20 +66,20 @@ def generate_baracoda_barcodes(config: Config, num_required: int) -> list:
                 return barcodes
             else:
                 retries = retries - 1
-                logger.error("Unable to create COG barcodes")
+                logger.error(TEST_DATA_ERROR_BARACODA_COG_BARCODES)
                 logger.error(response.json())
-                except_obj = Exception("Unable to create COG barcodes")
-        except requests.ConnectionError:
+                except_obj = CherrypickerDataError(TEST_DATA_ERROR_BARACODA_COG_BARCODES)
+        except requests.ConnectionError as e:
             retries = retries - 1
-            logger.error("Unable to access baracoda")
-            except_obj = requests.ConnectionError("Unable to access baracoda")
+            logger.error(TEST_DATA_ERROR_BARACODA_CONNECTION)
+            except_obj = CherrypickerDataError(f"{TEST_DATA_ERROR_BARACODA_CONNECTION} -- {str(e)}")
         except Exception:
             retries = retries - 1
-            logger.error("Unknown error accessing baracoda")
+            logger.error(TEST_DATA_ERROR_BARACODA_UNKNOWN)
 
     if except_obj is not None:
         raise except_obj
-    raise Exception("Unknown error accessing baracoda")
+    raise CherrypickerDataError(TEST_DATA_ERROR_BARACODA_UNKNOWN)
 
 
 def create_barcodes(config: Config, num_required: int) -> list:

--- a/crawler/helpers/exceptions.py
+++ b/crawler/helpers/exceptions.py
@@ -1,0 +1,3 @@
+class CherrypickerDataError(Exception):
+    def __init__(self, message):
+        self.message = message

--- a/crawler/jobs/cherrypicker_test_data.py
+++ b/crawler/jobs/cherrypicker_test_data.py
@@ -39,16 +39,12 @@ from crawler.helpers.cherrypicker_test_data import (
     create_csv_rows,
     write_plates_file,
 )
+from crawler.helpers.exceptions import CherrypickerDataError
 from crawler.helpers.general_helpers import get_config
 from crawler.main import run as run_crawler
 from crawler.types import Config
 
 logger = logging.getLogger(__name__)
-
-
-class CherrypickerDataError(Exception):
-    def __init__(self, message):
-        self.message = message
 
 
 def process(run_id: str, config: Config = None) -> List[List[str]]:

--- a/crawler/routes/common/cherrypicker_test_data.py
+++ b/crawler/routes/common/cherrypicker_test_data.py
@@ -4,8 +4,9 @@ from datetime import datetime, timezone
 from flask import request
 
 from crawler.constants import FIELD_STATUS_COMPLETED, FLASK_ERROR_MISSING_PARAMETERS, FLASK_ERROR_UNEXPECTED
+from crawler.helpers.exceptions import CherrypickerDataError
 from crawler.helpers.responses import bad_request, internal_server_error, ok
-from crawler.jobs.cherrypicker_test_data import CherrypickerDataError, process
+from crawler.jobs.cherrypicker_test_data import process
 from crawler.types import FlaskResponse
 
 logger = logging.getLogger(__name__)

--- a/crawler/types.py
+++ b/crawler/types.py
@@ -56,6 +56,7 @@ class Config(ModuleType):
 
     # Baracoda
     BARACODA_BASE_URL: str
+    BARACODA_RETRY_ATTEMPTS: int
 
     # Mongo
     MONGO_URI: str

--- a/tests/helpers/test_cherrypicker_data_helper.py
+++ b/tests/helpers/test_cherrypicker_data_helper.py
@@ -27,6 +27,7 @@ from crawler.helpers.cherrypicker_test_data import (
     generate_baracoda_barcodes,
     write_plates_file,
 )
+from crawler.helpers.exceptions import CherrypickerDataError
 from crawler.helpers.general_helpers import is_found_in_list
 
 LoggerMessages = namedtuple("LoggerMessages", ["info", "error"])
@@ -131,7 +132,7 @@ def test_generate_baracoda_barcodes_will_retry_if_exception(config, count, excep
         status=HTTPStatus.INTERNAL_SERVER_ERROR,
     )
 
-    with pytest.raises(exception_type):
+    with pytest.raises(CherrypickerDataError):
         generate_baracoda_barcodes(config, count)
 
     assert len(mocked_responses.calls) == config.BARACODA_RETRY_ATTEMPTS


### PR DESCRIPTION
Change to HTTPS, improve logging of errors when trying to connect to Baracoda and make development use a local instance of Baracoda.