### PR TITLE
Simplify the running/healthy state of the RabbitStack

### DIFF
--- a/crawler/rabbit/async_consumer.py
+++ b/crawler/rabbit/async_consumer.py
@@ -53,10 +53,6 @@ class AsyncConsumer(object):
         # for higher consumer throughput
         self._prefetch_count = 1
 
-    @property
-    def is_healthy(self):
-        return self._consuming or self.should_reconnect
-
     @staticmethod
     def _reap_last_connection_workflow_error(error):
         """Extract exception value from the last connection attempt

--- a/crawler/rabbit/background_consumer.py
+++ b/crawler/rabbit/background_consumer.py
@@ -16,6 +16,7 @@ class BackgroundConsumer(Thread):
         super().__init__()
         self.name = type(self).__name__
         self.daemon = True
+        self._running = False
         self._reconnect_delay = 0
         self._server_details = server_details
         self._queue = queue
@@ -23,17 +24,21 @@ class BackgroundConsumer(Thread):
         self._consumer_var = None
 
     def run(self):
-        while True:
-            try:
-                self._consumer.run()
-            except KeyboardInterrupt:
-                self._consumer.stop()
-                break
-            self._maybe_reconnect()
+        self._running = True
+        try:
+            while True:
+                try:
+                    self._consumer.run()
+                except KeyboardInterrupt:
+                    self._consumer.stop()
+                    break
+                self._maybe_reconnect()
+        finally:
+            self._running = False
 
     @property
     def is_healthy(self):
-        return self._consumer.is_healthy
+        return self._running
 
     @property
     def _consumer(self):


### PR DESCRIPTION
Changes proposed in this pull request:

* Instead of tracking the actual connected/disconnected/reconnecting state of the consumer, we can break the healthy state of the Rabbit Stack down into a simple "Have we begun running the consumer?"/"Has the consumer stopped and is not going to reconnect?" condition.
