### PR TITLE
DPL-200: Add a processor and message object for update messages and feedback

### DIFF
--- a/crawler/constants.py
+++ b/crawler/constants.py
@@ -274,9 +274,12 @@ RABBITMQ_HEADER_KEY_SUBJECT = "subject"
 RABBITMQ_HEADER_KEY_VERSION = "version"
 
 RABBITMQ_ROUTING_KEY_CREATE_PLATE_FEEDBACK = "feedback.created.plate"
+RABBITMQ_ROUTING_KEY_UPDATE_SAMPLE_FEEDBACK = "feedback.updated.sample"
 
 RABBITMQ_SUBJECT_CREATE_PLATE = "create-plate-map"
 RABBITMQ_SUBJECT_CREATE_PLATE_FEEDBACK = "create-plate-map-feedback"
+RABBITMQ_SUBJECT_UPDATE_SAMPLE = "update-plate-map-sample"
+RABBITMQ_SUBJECT_UPDATE_SAMPLE_FEEDBACK = "update-plate-map-sample-feedback"
 
 
 ###

--- a/crawler/processing/base_processor.py
+++ b/crawler/processing/base_processor.py
@@ -1,0 +1,7 @@
+from typing import Callable
+
+from crawler.processing.rabbit_message import RabbitMessage
+
+
+class BaseProcessor:
+    process: Callable[["BaseProcessor", RabbitMessage], bool]

--- a/crawler/processing/create_plate_processor.py
+++ b/crawler/processing/create_plate_processor.py
@@ -7,6 +7,7 @@ from crawler.constants import (
     RABBITMQ_SUBJECT_CREATE_PLATE_FEEDBACK,
 )
 from crawler.exceptions import TransientRabbitError
+from crawler.processing.base_processor import BaseProcessor
 from crawler.processing.create_plate_exporter import CreatePlateExporter
 from crawler.processing.create_plate_validator import CreatePlateValidator
 from crawler.rabbit.avro_encoder import AvroEncoder
@@ -16,7 +17,7 @@ from crawler.rabbit.messages.create_plate_message import CreatePlateError, Creat
 LOGGER = logging.getLogger(__name__)
 
 
-class CreatePlateProcessor:
+class CreatePlateProcessor(BaseProcessor):
     def __init__(self, schema_registry, basic_publisher, config):
         self._encoder = AvroEncoder(schema_registry, RABBITMQ_SUBJECT_CREATE_PLATE_FEEDBACK)
         self._basic_publisher = basic_publisher

--- a/crawler/processing/rabbit_message_processor.py
+++ b/crawler/processing/rabbit_message_processor.py
@@ -1,9 +1,10 @@
 import logging
 
-from crawler.constants import RABBITMQ_SUBJECT_CREATE_PLATE
+from crawler.constants import RABBITMQ_SUBJECT_CREATE_PLATE, RABBITMQ_SUBJECT_UPDATE_SAMPLE
 from crawler.exceptions import TransientRabbitError
 from crawler.processing.create_plate_processor import CreatePlateProcessor
 from crawler.processing.rabbit_message import RabbitMessage
+from crawler.processing.update_sample_processor import UpdateSampleProcessor
 from crawler.rabbit.avro_encoder import AvroEncoder
 
 LOGGER = logging.getLogger(__name__)
@@ -18,7 +19,10 @@ class RabbitMessageProcessor:
         self._processors = {
             RABBITMQ_SUBJECT_CREATE_PLATE: CreatePlateProcessor(
                 self._schema_registry, self._basic_publisher, self._config
-            )
+            ),
+            RABBITMQ_SUBJECT_UPDATE_SAMPLE: UpdateSampleProcessor(
+                self._schema_registry, self._basic_publisher, self._config
+            ),
         }
 
     def process_message(self, headers, body):

--- a/crawler/processing/update_sample_processor.py
+++ b/crawler/processing/update_sample_processor.py
@@ -1,0 +1,39 @@
+import logging
+
+from crawler.config.defaults import RABBITMQ_FEEDBACK_EXCHANGE
+from crawler.constants import RABBITMQ_ROUTING_KEY_UPDATE_SAMPLE_FEEDBACK, RABBITMQ_SUBJECT_UPDATE_SAMPLE_FEEDBACK
+from crawler.processing.base_processor import BaseProcessor
+from crawler.rabbit.avro_encoder import AvroEncoder
+from crawler.rabbit.messages.update_feedback_message import UpdateFeedbackMessage
+from crawler.rabbit.messages.update_sample_message import UpdateSampleMessage
+
+LOGGER = logging.getLogger(__name__)
+
+
+class UpdateSampleProcessor(BaseProcessor):
+    def __init__(self, schema_registry, basic_publisher, config):
+        self._encoder = AvroEncoder(schema_registry, RABBITMQ_SUBJECT_UPDATE_SAMPLE_FEEDBACK)
+        self._basic_publisher = basic_publisher
+        self._config = config
+
+    def process(self, message):
+        update_message = UpdateSampleMessage(message.message)
+        self._publish_feedback(update_message)
+
+        return True  # Acknowledge the message has been processed
+
+    def _publish_feedback(self, update_message):
+        feedback_message = UpdateFeedbackMessage(
+            sourceMessageUuid=update_message.message_uuid.value,
+            operationWasErrorFree=not update_message.has_errors,
+            errors=update_message.feedback_errors,
+        )
+
+        encoded_message = self._encoder.encode([feedback_message])
+        self._basic_publisher.publish_message(
+            RABBITMQ_FEEDBACK_EXCHANGE,
+            RABBITMQ_ROUTING_KEY_UPDATE_SAMPLE_FEEDBACK,
+            encoded_message.body,
+            RABBITMQ_SUBJECT_UPDATE_SAMPLE_FEEDBACK,
+            encoded_message.version,
+        )

--- a/crawler/rabbit/messages/base_message.py
+++ b/crawler/rabbit/messages/base_message.py
@@ -1,2 +1,23 @@
 class BaseMessage:
-    pass
+    def __init__(self):
+        self._textual_errors = []
+
+    @property
+    def textual_errors_summary(self):
+        error_count = len(self._textual_errors)
+
+        if error_count == 0:
+            errors_label = "No errors were"
+        elif error_count == 1:
+            errors_label = "1 error was"
+        else:
+            errors_label = f"{error_count} errors were"
+
+        additional_text = " Only the first 5 are shown." if error_count > 5 else ""
+
+        error_list = [f"{errors_label} reported during processing.{additional_text}"] + self._textual_errors[:5]
+
+        return error_list
+
+    def add_textual_error(self, description):
+        self._textual_errors.append(description)

--- a/crawler/rabbit/messages/base_message.py
+++ b/crawler/rabbit/messages/base_message.py
@@ -1,0 +1,2 @@
+class BaseMessage:
+    pass

--- a/crawler/rabbit/messages/create_plate_message.py
+++ b/crawler/rabbit/messages/create_plate_message.py
@@ -103,32 +103,15 @@ class CreatePlateSample:
 
 class CreatePlateMessage(BaseMessage):
     def __init__(self, body):
+        super().__init__()
         self._body = body
         self.centre_config: Optional[CentreConf] = None
 
         self.validated_samples = 0
-        self._textual_errors = []
         self._feedback_errors = []
 
         self._duplicated_sample_values = None
         self._samples = None
-
-    @property
-    def textual_errors_summary(self):
-        error_count = len(self._textual_errors)
-
-        if error_count == 0:
-            errors_label = "No errors were"
-        elif error_count == 1:
-            errors_label = "1 error was"
-        else:
-            errors_label = f"{error_count} errors were"
-
-        additional_text = " Only the first 5 are shown." if error_count > 5 else ""
-
-        error_list = [f"{errors_label} reported during processing.{additional_text}"] + self._textual_errors[:5]
-
-        return error_list
 
     @property
     def feedback_errors(self):
@@ -136,7 +119,7 @@ class CreatePlateMessage(BaseMessage):
 
     @property
     def has_errors(self):
-        return len(self._textual_errors) > 0 or len(self._feedback_errors) > 0
+        return len(self._feedback_errors) > 0
 
     @property
     def total_samples(self):
@@ -182,7 +165,7 @@ class CreatePlateMessage(BaseMessage):
 
     def add_error(self, create_error):
         LOGGER.error(f"Error in create plate message: {create_error.description}")
-        self._textual_errors.append(create_error.description)
+        self.add_textual_error(create_error.description)
         self._feedback_errors.append(
             CreateFeedbackError(
                 typeId=int(create_error.type),

--- a/crawler/rabbit/messages/create_plate_message.py
+++ b/crawler/rabbit/messages/create_plate_message.py
@@ -5,6 +5,7 @@ from typing import Any, NamedTuple, Optional
 
 from crawler.helpers.general_helpers import extract_duplicated_values as extract_dupes
 from crawler.helpers.sample_data_helpers import normalise_plate_coordinate
+from crawler.rabbit.messages.base_message import BaseMessage
 from crawler.rabbit.messages.create_feedback_message import CreateFeedbackError
 from crawler.types import CentreConf
 
@@ -100,7 +101,7 @@ class CreatePlateSample:
         return MessageField(FIELD_TESTED_DATE, self._body[FIELD_TESTED_DATE])
 
 
-class CreatePlateMessage:
+class CreatePlateMessage(BaseMessage):
     def __init__(self, body):
         self._body = body
         self.centre_config: Optional[CentreConf] = None

--- a/crawler/rabbit/messages/update_feedback_message.py
+++ b/crawler/rabbit/messages/update_feedback_message.py
@@ -1,0 +1,16 @@
+from typing import List, TypedDict
+
+from typing_extensions import NotRequired
+
+
+class UpdateFeedbackError(TypedDict):
+    typeId: int
+    origin: str
+    field: NotRequired[str]
+    description: str
+
+
+class UpdateFeedbackMessage(TypedDict):
+    sourceMessageUuid: str
+    operationWasErrorFree: bool
+    errors: List[UpdateFeedbackError]

--- a/crawler/rabbit/messages/update_sample_message.py
+++ b/crawler/rabbit/messages/update_sample_message.py
@@ -37,28 +37,11 @@ class UpdateSampleError:
 
 class UpdateSampleMessage(BaseMessage):
     def __init__(self, body):
+        super().__init__()
         self._body = body
 
-        self._textual_errors = []
         self._feedback_errors = []
         self._updated_fields = None
-
-    @property
-    def textual_errors_summary(self):
-        error_count = len(self._textual_errors)
-
-        if error_count == 0:
-            errors_label = "No errors were"
-        elif error_count == 1:
-            errors_label = "1 error was"
-        else:
-            errors_label = f"{error_count} errors were"
-
-        additional_text = " Only the first 5 are shown." if error_count > 5 else ""
-
-        error_list = [f"{errors_label} reported during processing.{additional_text}"] + self._textual_errors[:5]
-
-        return error_list
 
     @property
     def feedback_errors(self):
@@ -66,7 +49,7 @@ class UpdateSampleMessage(BaseMessage):
 
     @property
     def has_errors(self):
-        return len(self._textual_errors) > 0 or len(self._feedback_errors) > 0
+        return len(self._feedback_errors) > 0
 
     @property
     def message_uuid(self):
@@ -92,7 +75,7 @@ class UpdateSampleMessage(BaseMessage):
 
     def add_error(self, update_error):
         LOGGER.error(f"Error in create plate message: {update_error.description}")
-        self._textual_errors.append(update_error.description)
+        self.add_textual_error(update_error.description)
         self._feedback_errors.append(
             UpdateFeedbackError(
                 typeId=int(update_error.type),

--- a/crawler/rabbit/messages/update_sample_message.py
+++ b/crawler/rabbit/messages/update_sample_message.py
@@ -4,7 +4,7 @@ from enum import IntEnum
 from typing import Any, NamedTuple, Optional
 
 from crawler.rabbit.messages.base_message import BaseMessage
-from crawler.rabbit.messages.create_feedback_message import CreateFeedbackError
+from crawler.rabbit.messages.update_feedback_message import UpdateFeedbackError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -90,15 +90,14 @@ class UpdateSampleMessage(BaseMessage):
 
         return MessageField(FIELD_UPDATED_FIELDS, self._updated_fields)
 
-    def add_error(self, create_error):
-        LOGGER.error(f"Error in create plate message: {create_error.description}")
-        self._textual_errors.append(create_error.description)
+    def add_error(self, update_error):
+        LOGGER.error(f"Error in create plate message: {update_error.description}")
+        self._textual_errors.append(update_error.description)
         self._feedback_errors.append(
-            CreateFeedbackError(
-                typeId=int(create_error.type),
-                origin=create_error.origin,
-                sampleUuid=create_error.sample_uuid,
-                field=create_error.field,
-                description=create_error.description,
+            UpdateFeedbackError(
+                typeId=int(update_error.type),
+                origin=update_error.origin,
+                field=update_error.field,
+                description=update_error.description,
             )
         )

--- a/crawler/rabbit/messages/update_sample_message.py
+++ b/crawler/rabbit/messages/update_sample_message.py
@@ -9,12 +9,12 @@ from crawler.rabbit.messages.create_feedback_message import CreateFeedbackError
 LOGGER = logging.getLogger(__name__)
 
 
-FIELD_MESSAGE_UUID = "messageUuid"
 FIELD_MESSAGE_CREATE_DATE = "messageCreateDateUtc"
+FIELD_MESSAGE_UUID = "messageUuid"
+FIELD_NAME = "name"
 FIELD_SAMPLE = "sample"
 FIELD_SAMPLE_UUID = "sampleUuid"
 FIELD_UPDATED_FIELDS = "updatedFields"
-FIELD_NAME = "name"
 FIELD_VALUE = "value"
 
 
@@ -78,7 +78,7 @@ class UpdateSampleMessage(BaseMessage):
 
     @property
     def sample_uuid(self):
-        return MessageField(FIELD_SAMPLE_UUID, self._body[FIELD_SAMPLE][FIELD_SAMPLE_UUID])
+        return MessageField(FIELD_SAMPLE_UUID, self._body[FIELD_SAMPLE][FIELD_SAMPLE_UUID].decode())
 
     @property
     def updated_fields(self):

--- a/crawler/rabbit/messages/update_sample_message.py
+++ b/crawler/rabbit/messages/update_sample_message.py
@@ -1,0 +1,104 @@
+import logging
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any, NamedTuple, Optional
+
+from crawler.rabbit.messages.base_message import BaseMessage
+from crawler.rabbit.messages.create_feedback_message import CreateFeedbackError
+
+LOGGER = logging.getLogger(__name__)
+
+
+FIELD_MESSAGE_UUID = "messageUuid"
+FIELD_MESSAGE_CREATE_DATE = "messageCreateDateUtc"
+FIELD_SAMPLE = "sample"
+FIELD_SAMPLE_UUID = "sampleUuid"
+FIELD_UPDATED_FIELDS = "updatedFields"
+FIELD_NAME = "name"
+FIELD_VALUE = "value"
+
+
+class ErrorType(IntEnum):
+    UnhandledProcessingError = 101
+
+
+class MessageField(NamedTuple):
+    name: str
+    value: Any
+
+
+@dataclass
+class UpdateSampleError:
+    type: ErrorType
+    origin: str
+    description: str
+    field: Optional[str] = None
+
+
+class UpdateSampleMessage(BaseMessage):
+    def __init__(self, body):
+        self._body = body
+
+        self._textual_errors = []
+        self._feedback_errors = []
+        self._updated_fields = None
+
+    @property
+    def textual_errors_summary(self):
+        error_count = len(self._textual_errors)
+
+        if error_count == 0:
+            errors_label = "No errors were"
+        elif error_count == 1:
+            errors_label = "1 error was"
+        else:
+            errors_label = f"{error_count} errors were"
+
+        additional_text = " Only the first 5 are shown." if error_count > 5 else ""
+
+        error_list = [f"{errors_label} reported during processing.{additional_text}"] + self._textual_errors[:5]
+
+        return error_list
+
+    @property
+    def feedback_errors(self):
+        return self._feedback_errors.copy()
+
+    @property
+    def has_errors(self):
+        return len(self._textual_errors) > 0 or len(self._feedback_errors) > 0
+
+    @property
+    def message_uuid(self):
+        return MessageField(FIELD_MESSAGE_UUID, self._body[FIELD_MESSAGE_UUID].decode())
+
+    @property
+    def message_create_date(self):
+        return MessageField(FIELD_MESSAGE_CREATE_DATE, self._body[FIELD_MESSAGE_CREATE_DATE])
+
+    @property
+    def sample_uuid(self):
+        return MessageField(FIELD_SAMPLE_UUID, self._body[FIELD_SAMPLE][FIELD_SAMPLE_UUID])
+
+    @property
+    def updated_fields(self):
+        if self._updated_fields is None:
+            self._updated_fields = [
+                MessageField(name=body[FIELD_NAME], value=body[FIELD_VALUE])
+                for body in self._body[FIELD_SAMPLE][FIELD_UPDATED_FIELDS]
+            ]
+
+        return MessageField(FIELD_UPDATED_FIELDS, self._updated_fields)
+
+    def add_error(self, create_error):
+        LOGGER.error(f"Error in create plate message: {create_error.description}")
+        self._textual_errors.append(create_error.description)
+        self._feedback_errors.append(
+            CreateFeedbackError(
+                typeId=int(create_error.type),
+                origin=create_error.origin,
+                sampleUuid=create_error.sample_uuid,
+                field=create_error.field,
+                description=create_error.description,
+            )
+        )

--- a/tests/processing/test_update_sample_processor.py
+++ b/tests/processing/test_update_sample_processor.py
@@ -1,0 +1,95 @@
+import copy
+from typing import NamedTuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crawler.config.defaults import RABBITMQ_FEEDBACK_EXCHANGE
+from crawler.constants import RABBITMQ_ROUTING_KEY_UPDATE_SAMPLE_FEEDBACK, RABBITMQ_SUBJECT_UPDATE_SAMPLE_FEEDBACK
+from crawler.processing.update_sample_processor import UpdateSampleProcessor
+from crawler.rabbit.messages.update_feedback_message import UpdateFeedbackMessage
+from crawler.rabbit.messages.update_sample_message import MessageField, UpdateSampleMessage
+from tests.testing_objects import UPDATE_SAMPLE_MESSAGE
+
+
+class EncodedMessage(NamedTuple):
+    body: bytes
+    version: str
+
+
+ENCODED_MESSAGE = EncodedMessage(body=b'{"key": "value"}', version="1")
+
+
+@pytest.fixture
+def logger():
+    with patch("crawler.processing.update_sample_processor.LOGGER") as logger:
+        yield logger
+
+
+@pytest.fixture
+def avro_encoder():
+    with patch("crawler.processing.update_sample_processor.AvroEncoder") as avro_encoder:
+        avro_encoder.return_value.encode.return_value = ENCODED_MESSAGE
+        yield avro_encoder
+
+
+@pytest.fixture
+def update_sample_message():
+    return UpdateSampleMessage(copy.deepcopy(UPDATE_SAMPLE_MESSAGE))
+
+
+@pytest.fixture
+def message_wrapper_class():
+    with patch("crawler.processing.update_sample_processor.UpdateSampleMessage") as message_wrapper_class:
+        message_wrapper_class.return_value.message_uuid = MessageField("UUID_FIELD", "UUID")
+        message_wrapper_class.return_value.has_errors = False
+
+        def add_error(error):
+            message_wrapper_class.return_value.has_errors = True
+
+        message_wrapper_class.return_value.add_error.side_effect = add_error
+
+        yield message_wrapper_class
+
+
+@pytest.fixture
+def subject(config, avro_encoder):
+    return UpdateSampleProcessor(MagicMock(), MagicMock(), config)
+
+
+def assert_feedback_was_published(subject, message, avro_encoder):
+    feedback_message = UpdateFeedbackMessage(
+        sourceMessageUuid=message.message_uuid.value,
+        operationWasErrorFree=not message.has_errors,
+        errors=message.feedback_errors,
+    )
+
+    avro_encoder.encode.assert_called_once()
+    assert avro_encoder.encode.call_args.args[0][0] == feedback_message
+
+    subject._basic_publisher.publish_message.assert_called_once_with(
+        RABBITMQ_FEEDBACK_EXCHANGE,
+        RABBITMQ_ROUTING_KEY_UPDATE_SAMPLE_FEEDBACK,
+        ENCODED_MESSAGE.body,
+        RABBITMQ_SUBJECT_UPDATE_SAMPLE_FEEDBACK,
+        ENCODED_MESSAGE.version,
+    )
+
+
+def test_constructor_creates_appropriate_encoder(avro_encoder):
+    schema_registry = MagicMock()
+    UpdateSampleProcessor(schema_registry, MagicMock(), MagicMock())
+
+    avro_encoder.assert_called_once_with(schema_registry, RABBITMQ_SUBJECT_UPDATE_SAMPLE_FEEDBACK)
+
+
+def test_process_publishes_feedback_when_no_issues_found(subject, message_wrapper_class, avro_encoder):
+    subject.process(MagicMock())
+
+    assert_feedback_was_published(subject, message_wrapper_class.return_value, avro_encoder.return_value)
+
+
+def test_process_returns_true_when_no_issues_found(subject):
+    result = subject.process(MagicMock())
+
+    assert result is True

--- a/tests/rabbit/messages/test_base_message.py
+++ b/tests/rabbit/messages/test_base_message.py
@@ -1,0 +1,36 @@
+import pytest
+
+from crawler.rabbit.messages.base_message import BaseMessage
+
+
+@pytest.fixture
+def subject():
+    return BaseMessage()
+
+
+@pytest.mark.parametrize(
+    "errors, headline",
+    [
+        [[], "No errors were reported during processing."],
+        [["Error 1"], "1 error was reported during processing."],
+        [["Error 1", "Error 2"], "2 errors were reported during processing."],
+        [["Error 1", "Error 2", "Error 3"], "3 errors were reported during processing."],
+        [["Error 1", "Error 2", "Error 3", "Error 4"], "4 errors were reported during processing."],
+        [["Error 1", "Error 2", "Error 3", "Error 4", "Error 5"], "5 errors were reported during processing."],
+    ],
+)
+def test_textual_errors_summary_is_accurate_for_up_to_5_errors(subject, errors, headline):
+    subject._textual_errors = errors
+    assert subject.textual_errors_summary == [headline] + errors
+
+
+def test_textual_errors_summary_is_accurate_for_6_errors(subject):
+    subject._textual_errors = ["Error 1", "Error 2", "Error 3", "Error 4", "Error 5", "Error 6"]
+    assert subject.textual_errors_summary == [
+        "6 errors were reported during processing. Only the first 5 are shown.",
+        "Error 1",
+        "Error 2",
+        "Error 3",
+        "Error 4",
+        "Error 5",
+    ]

--- a/tests/rabbit/messages/test_create_plate_message.py
+++ b/tests/rabbit/messages/test_create_plate_message.py
@@ -52,11 +52,6 @@ def test_has_errors_is_true_after_feedback_error_logged(subject):
     assert subject.has_errors is True
 
 
-def test_has_errors_is_true_after_textual_error_logged(subject):
-    subject._textual_errors.append(MagicMock())
-    assert subject.has_errors is True
-
-
 def test_total_samples_gives_expected_value(subject):
     assert subject.total_samples == 3
 
@@ -277,31 +272,3 @@ def test_feedback_errors_list_is_immutable(subject):
     errors.remove(errors[0])
     assert len(errors) == 0
     assert len(subject.feedback_errors) == 1  # Hasn't been modified
-
-
-@pytest.mark.parametrize(
-    "errors, headline",
-    [
-        [[], "No errors were reported during processing."],
-        [["Error 1"], "1 error was reported during processing."],
-        [["Error 1", "Error 2"], "2 errors were reported during processing."],
-        [["Error 1", "Error 2", "Error 3"], "3 errors were reported during processing."],
-        [["Error 1", "Error 2", "Error 3", "Error 4"], "4 errors were reported during processing."],
-        [["Error 1", "Error 2", "Error 3", "Error 4", "Error 5"], "5 errors were reported during processing."],
-    ],
-)
-def test_textual_errors_summary_is_accurate_for_up_to_5_errors(subject, errors, headline):
-    subject._textual_errors = errors
-    assert subject.textual_errors_summary == [headline] + errors
-
-
-def test_textual_errors_summary_is_accurate_for_6_errors(subject):
-    subject._textual_errors = ["Error 1", "Error 2", "Error 3", "Error 4", "Error 5", "Error 6"]
-    assert subject.textual_errors_summary == [
-        "6 errors were reported during processing. Only the first 5 are shown.",
-        "Error 1",
-        "Error 2",
-        "Error 3",
-        "Error 4",
-        "Error 5",
-    ]

--- a/tests/rabbit/messages/test_update_sample_message.py
+++ b/tests/rabbit/messages/test_update_sample_message.py
@@ -1,0 +1,140 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crawler.rabbit.messages.update_sample_message import (
+    FIELD_MESSAGE_CREATE_DATE,
+    FIELD_MESSAGE_UUID,
+    ErrorType,
+    UpdateSampleError,
+    UpdateSampleMessage,
+)
+from tests.testing_objects import UPDATE_SAMPLE_MESSAGE
+
+
+@pytest.fixture
+def logger():
+    with patch("crawler.rabbit.messages.update_sample_message.LOGGER") as logger:
+        yield logger
+
+
+@pytest.fixture
+def subject():
+    return UpdateSampleMessage(UPDATE_SAMPLE_MESSAGE)
+
+
+def test_has_errors_is_initially_false(subject):
+    assert subject.has_errors is False
+
+
+def test_has_errors_is_true_after_feedback_error_logged(subject):
+    subject._feedback_errors.append(MagicMock())
+    assert subject.has_errors is True
+
+
+def test_has_errors_is_true_after_textual_error_logged(subject):
+    subject._textual_errors.append(MagicMock())
+    assert subject.has_errors is True
+
+
+def test_message_uuid_gives_expected_value(subject):
+    assert subject.message_uuid.name == FIELD_MESSAGE_UUID
+    assert subject.message_uuid.value == "UPDATE_SAMPLE_MESSAGE_UUID"
+
+
+def test_message_create_date_gives_expected_value(subject):
+    assert subject.message_create_date.name == FIELD_MESSAGE_CREATE_DATE
+    assert type(subject.message_create_date.value) == datetime
+
+
+@pytest.mark.parametrize("description", ["description_1", "description_2"])
+def test_add_error_logs_the_error_description(subject, logger, description):
+    subject.add_error(
+        UpdateSampleError(
+            type=ErrorType.UnhandledProcessingError,
+            origin="origin",
+            description=description,
+        )
+    )
+
+    logger.error.assert_called_once()
+    logged_error = logger.error.call_args.args[0]
+    assert description in logged_error
+
+
+@pytest.mark.parametrize("description", ["description_1", "description_2"])
+def test_add_error_records_the_textual_error(subject, description):
+    subject.add_error(
+        UpdateSampleError(
+            type=ErrorType.UnhandledProcessingError,
+            origin="origin",
+            description=description,
+        )
+    )
+
+    assert len(subject._textual_errors) == 1
+    added_error = subject._textual_errors[0]
+    assert added_error == description
+
+
+@pytest.mark.parametrize("type", [ErrorType.UnhandledProcessingError])
+@pytest.mark.parametrize("origin", ["origin_1", "origin_2"])
+@pytest.mark.parametrize("description", ["description_1", "description_2"])
+@pytest.mark.parametrize("field", ["field_1", "field_2"])
+def test_add_error_records_the_feedback_error(subject, type, origin, description, field):
+    subject.add_error(
+        UpdateSampleError(
+            type=type,
+            origin=origin,
+            description=description,
+            field=field,
+        )
+    )
+
+    assert len(subject.feedback_errors) == 1
+    added_error = subject.feedback_errors[0]
+    assert added_error["typeId"] == int(type)
+    assert added_error["origin"] == origin
+    assert added_error["description"] == description
+    assert added_error["field"] == field
+
+
+def test_feedback_errors_list_is_immutable(subject):
+    subject.add_error(
+        UpdateSampleError(type=ErrorType.UnhandledProcessingError, origin="origin", description="description")
+    )
+
+    errors = subject.feedback_errors
+    assert len(errors) == 1
+    errors.remove(errors[0])
+    assert len(errors) == 0
+    assert len(subject.feedback_errors) == 1  # Hasn't been modified
+
+
+@pytest.mark.parametrize(
+    "errors, headline",
+    [
+        [[], "No errors were reported during processing."],
+        [["Error 1"], "1 error was reported during processing."],
+        [["Error 1", "Error 2"], "2 errors were reported during processing."],
+        [["Error 1", "Error 2", "Error 3"], "3 errors were reported during processing."],
+        [["Error 1", "Error 2", "Error 3", "Error 4"], "4 errors were reported during processing."],
+        [["Error 1", "Error 2", "Error 3", "Error 4", "Error 5"], "5 errors were reported during processing."],
+    ],
+)
+def test_textual_errors_summary_is_accurate_for_up_to_5_errors(subject, errors, headline):
+    subject._textual_errors = errors
+    assert subject.textual_errors_summary == [headline] + errors
+
+
+def test_textual_errors_summary_is_accurate_for_6_errors(subject):
+    subject._textual_errors = ["Error 1", "Error 2", "Error 3", "Error 4", "Error 5", "Error 6"]
+    assert subject.textual_errors_summary == [
+        "6 errors were reported during processing. Only the first 5 are shown.",
+        "Error 1",
+        "Error 2",
+        "Error 3",
+        "Error 4",
+        "Error 5",
+    ]

--- a/tests/rabbit/messages/test_update_sample_message.py
+++ b/tests/rabbit/messages/test_update_sample_message.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from crawler.rabbit.messages.create_plate_message import FIELD_SAMPLE_UUID
 from crawler.rabbit.messages.update_sample_message import (
     FIELD_MESSAGE_CREATE_DATE,
     FIELD_MESSAGE_UUID,
@@ -41,6 +42,21 @@ def test_message_uuid_gives_expected_value(subject):
 def test_message_create_date_gives_expected_value(subject):
     assert subject.message_create_date.name == FIELD_MESSAGE_CREATE_DATE
     assert type(subject.message_create_date.value) == datetime
+
+
+def test_sample_uuid_gives_expected_value(subject):
+    assert subject.sample_uuid.name == FIELD_SAMPLE_UUID
+    assert subject.sample_uuid.value == "UPDATE_SAMPLE_UUID"
+
+
+def test_updated_fields_gives_expected_values(subject):
+    assert len(subject.updated_fields) == 2
+
+    msField = next(x for x in subject.updated_fields.value if x.name == "mustSequence")
+    assert msField.value is True
+
+    psField = next(x for x in subject.updated_fields.value if x.name == "preferentiallySequence")
+    assert psField.value is False
 
 
 @pytest.mark.parametrize("description", ["description_1", "description_2"])

--- a/tests/rabbit/messages/test_update_sample_message.py
+++ b/tests/rabbit/messages/test_update_sample_message.py
@@ -33,11 +33,6 @@ def test_has_errors_is_true_after_feedback_error_logged(subject):
     assert subject.has_errors is True
 
 
-def test_has_errors_is_true_after_textual_error_logged(subject):
-    subject._textual_errors.append(MagicMock())
-    assert subject.has_errors is True
-
-
 def test_message_uuid_gives_expected_value(subject):
     assert subject.message_uuid.name == FIELD_MESSAGE_UUID
     assert subject.message_uuid.value == "UPDATE_SAMPLE_MESSAGE_UUID"
@@ -110,31 +105,3 @@ def test_feedback_errors_list_is_immutable(subject):
     errors.remove(errors[0])
     assert len(errors) == 0
     assert len(subject.feedback_errors) == 1  # Hasn't been modified
-
-
-@pytest.mark.parametrize(
-    "errors, headline",
-    [
-        [[], "No errors were reported during processing."],
-        [["Error 1"], "1 error was reported during processing."],
-        [["Error 1", "Error 2"], "2 errors were reported during processing."],
-        [["Error 1", "Error 2", "Error 3"], "3 errors were reported during processing."],
-        [["Error 1", "Error 2", "Error 3", "Error 4"], "4 errors were reported during processing."],
-        [["Error 1", "Error 2", "Error 3", "Error 4", "Error 5"], "5 errors were reported during processing."],
-    ],
-)
-def test_textual_errors_summary_is_accurate_for_up_to_5_errors(subject, errors, headline):
-    subject._textual_errors = errors
-    assert subject.textual_errors_summary == [headline] + errors
-
-
-def test_textual_errors_summary_is_accurate_for_6_errors(subject):
-    subject._textual_errors = ["Error 1", "Error 2", "Error 3", "Error 4", "Error 5", "Error 6"]
-    assert subject.textual_errors_summary == [
-        "6 errors were reported during processing. Only the first 5 are shown.",
-        "Error 1",
-        "Error 2",
-        "Error 3",
-        "Error 4",
-        "Error 5",
-    ]

--- a/tests/testing_objects.py
+++ b/tests/testing_objects.py
@@ -69,15 +69,21 @@ from crawler.rabbit.messages.create_plate_message import FIELD_MUST_SEQUENCE as 
 from crawler.rabbit.messages.create_plate_message import FIELD_PLATE as CREATE_PLATE_PLATE
 from crawler.rabbit.messages.create_plate_message import FIELD_PLATE_BARCODE as CREATE_PLATE_PLATE_BARCODE
 from crawler.rabbit.messages.create_plate_message import FIELD_PLATE_COORDINATE as CREATE_PLATE_PLATE_COORDINATE
-from crawler.rabbit.messages.create_plate_message import (
-    FIELD_PREFERENTIALLY_SEQUENCE as CREATE_PLATE_PREFERENTIALLY_SEQUENCE,
-)
+from crawler.rabbit.messages.create_plate_message import \
+    FIELD_PREFERENTIALLY_SEQUENCE as CREATE_PLATE_PREFERENTIALLY_SEQUENCE
 from crawler.rabbit.messages.create_plate_message import FIELD_RESULT as CREATE_PLATE_RESULT
 from crawler.rabbit.messages.create_plate_message import FIELD_RNA_ID as CREATE_PLATE_RNA_ID
 from crawler.rabbit.messages.create_plate_message import FIELD_ROOT_SAMPLE_ID as CREATE_PLATE_ROOT_SAMPLE_ID
 from crawler.rabbit.messages.create_plate_message import FIELD_SAMPLE_UUID as CREATE_PLATE_SAMPLE_UUID
 from crawler.rabbit.messages.create_plate_message import FIELD_SAMPLES as CREATE_PLATE_SAMPLES
 from crawler.rabbit.messages.create_plate_message import FIELD_TESTED_DATE as CREATE_PLATE_TESTED_DATE
+from crawler.rabbit.messages.update_sample_message import FIELD_MESSAGE_CREATE_DATE as UPDATE_SAMPLE_MESSAGE_CREATE_DATE
+from crawler.rabbit.messages.update_sample_message import FIELD_MESSAGE_UUID as UPDATE_SAMPLE_MESSAGE_UUID
+from crawler.rabbit.messages.update_sample_message import FIELD_NAME as UPDATE_SAMPLE_NAME
+from crawler.rabbit.messages.update_sample_message import FIELD_SAMPLE as UPDATE_SAMPLE_SAMPLE
+from crawler.rabbit.messages.update_sample_message import FIELD_SAMPLE_UUID as UPDATE_SAMPLE_SAMPLE_UUID
+from crawler.rabbit.messages.update_sample_message import FIELD_UPDATED_FIELDS as UPDATE_SAMPLE_UPDATED_FIELDS
+from crawler.rabbit.messages.update_sample_message import FIELD_VALUE as UPDATE_SAMPLE_VALUE
 
 TESTING_SAMPLES: List[Dict[str, Union[str, bool, ObjectId]]] = [
     {
@@ -717,6 +723,25 @@ CREATE_PLATE_MESSAGE = {
                 CREATE_PLATE_FIT_TO_PICK: True,
                 CREATE_PLATE_RESULT: "void",
                 CREATE_PLATE_TESTED_DATE: datetime(2022, 4, 10, 11, 45, 25),
+            },
+        ],
+    },
+}
+
+
+UPDATE_SAMPLE_MESSAGE = {
+    UPDATE_SAMPLE_MESSAGE_UUID: b"UPDATE_SAMPLE_MESSAGE_UUID",
+    UPDATE_SAMPLE_MESSAGE_CREATE_DATE: datetime.utcnow(),
+    UPDATE_SAMPLE_SAMPLE: {
+        UPDATE_SAMPLE_SAMPLE_UUID: b"UPDATE_SAMPLE_UUID",
+        UPDATE_SAMPLE_UPDATED_FIELDS: [
+            {
+                UPDATE_SAMPLE_NAME: "mustSequence",
+                UPDATE_SAMPLE_VALUE: True,
+            },
+            {
+                UPDATE_SAMPLE_NAME: "preferentiallySequence",
+                UPDATE_SAMPLE_VALUE: True,
             },
         ],
     },

--- a/tests/testing_objects.py
+++ b/tests/testing_objects.py
@@ -742,7 +742,7 @@ UPDATE_SAMPLE_MESSAGE = {
             },
             {
                 UPDATE_SAMPLE_NAME: "preferentiallySequence",
-                UPDATE_SAMPLE_VALUE: True,
+                UPDATE_SAMPLE_VALUE: False,
             },
         ],
     },

--- a/tests/testing_objects.py
+++ b/tests/testing_objects.py
@@ -69,8 +69,9 @@ from crawler.rabbit.messages.create_plate_message import FIELD_MUST_SEQUENCE as 
 from crawler.rabbit.messages.create_plate_message import FIELD_PLATE as CREATE_PLATE_PLATE
 from crawler.rabbit.messages.create_plate_message import FIELD_PLATE_BARCODE as CREATE_PLATE_PLATE_BARCODE
 from crawler.rabbit.messages.create_plate_message import FIELD_PLATE_COORDINATE as CREATE_PLATE_PLATE_COORDINATE
-from crawler.rabbit.messages.create_plate_message import \
-    FIELD_PREFERENTIALLY_SEQUENCE as CREATE_PLATE_PREFERENTIALLY_SEQUENCE
+from crawler.rabbit.messages.create_plate_message import (
+    FIELD_PREFERENTIALLY_SEQUENCE as CREATE_PLATE_PREFERENTIALLY_SEQUENCE,
+)
 from crawler.rabbit.messages.create_plate_message import FIELD_RESULT as CREATE_PLATE_RESULT
 from crawler.rabbit.messages.create_plate_message import FIELD_RNA_ID as CREATE_PLATE_RNA_ID
 from crawler.rabbit.messages.create_plate_message import FIELD_ROOT_SAMPLE_ID as CREATE_PLATE_ROOT_SAMPLE_ID


### PR DESCRIPTION
Part of #471 

Changes proposed in this pull request:

* Add a processor for update messages.
* Add message schemas as Python objects and a parser.
* Give only error-free feedback (for now) after an update message has come in.
