### PR TITLE
Fix bug on writing to mysql when using mongodb with ch_q values

### DIFF
--- a/crawler/sql_queries.py
+++ b/crawler/sql_queries.py
@@ -165,10 +165,10 @@ SQL_MLWH_MARK_ALL_SAMPLES_NOT_MOST_RECENT = (
 SQL_MLWH_UPDATE_SAMPLE_UUID_PLATE_UUID = (
     f"UPDATE lighthouse_sample"
     f" SET"
-    f" { MLWH_LH_SAMPLE_UUID } = %(lh_sample_uuid)s,"
-    f" { MLWH_LH_SOURCE_PLATE_UUID } = %(lh_source_plate_uuid)s,"
-    f" { MLWH_UPDATED_AT } = %(updated_at)s"
-    f" WHERE { MLWH_MONGODB_ID } = %(_id)s"
+    f" { MLWH_LH_SAMPLE_UUID } = %({MLWH_LH_SAMPLE_UUID})s,"
+    f" { MLWH_LH_SOURCE_PLATE_UUID } = %({MLWH_LH_SOURCE_PLATE_UUID})s,"
+    f" { MLWH_UPDATED_AT } = %({MLWH_UPDATED_AT})s"
+    f" WHERE { MLWH_MONGODB_ID } = %({MLWH_MONGODB_ID})s"
 )
 
 

--- a/migrations/back_populate_source_plate_and_sample_uuids.py
+++ b/migrations/back_populate_source_plate_and_sample_uuids.py
@@ -24,7 +24,7 @@ from crawler.constants import (
 )
 from crawler.db.mongo import create_mongo_client, get_mongo_collection, get_mongo_db
 from crawler.db.mysql import create_mysql_connection, run_mysql_executemany_query
-from crawler.helpers.general_helpers import create_source_plate_doc
+from crawler.helpers.general_helpers import create_source_plate_doc, map_mongo_to_sql_common
 from crawler.sql_queries import SQL_MLWH_COUNT_MONGO_IDS, SQL_MLWH_UPDATE_SAMPLE_UUID_PLATE_UUID
 from crawler.types import Config, SampleDoc
 
@@ -363,8 +363,10 @@ def update_mlwh_sample_uuid_and_source_plate_uuid(config: Config, sample_doc: Sa
     mysql_conn = create_mysql_connection(config, False)
 
     if mysql_conn is not None and mysql_conn.is_connected():
+        sample_mongo = map_mongo_to_sql_common(sample_doc)
+        sample_mongo[FIELD_UPDATED_AT] = datetime.now()
         run_mysql_executemany_query(
-            mysql_conn, SQL_MLWH_UPDATE_SAMPLE_UUID_PLATE_UUID, [cast(Dict[str, str], sample_doc)]
+            mysql_conn, SQL_MLWH_UPDATE_SAMPLE_UUID_PLATE_UUID, [cast(Dict[str, str], sample_mongo)]
         )
         return True
     else:

--- a/tests/testing_objects.py
+++ b/tests/testing_objects.py
@@ -3,10 +3,12 @@ from decimal import Decimal
 from typing import Any, Dict, List, Union
 
 import dateutil.parser
+from bson.decimal128 import Decimal128
 from bson.objectid import ObjectId
 
 from crawler.constants import (
     EVENT_CHERRYPICK_LAYOUT_SET,
+    FIELD_CH1_CQ,
     FIELD_COORDINATE,
     FIELD_CREATED_AT,
     FIELD_FILTERED_POSITIVE,
@@ -131,7 +133,7 @@ TESTING_SAMPLES: List[Dict[str, Union[str, bool, ObjectId]]] = [
     },
 ]
 
-TESTING_SAMPLES_WITH_LAB_ID: List[Dict[str, Union[str, bool, ObjectId]]] = [
+TESTING_SAMPLES_WITH_LAB_ID: List[Dict[str, Union[str, bool, ObjectId, Decimal128]]] = [
     {
         FIELD_COORDINATE: "A01",
         FIELD_SOURCE: "Test Centre",
@@ -141,6 +143,9 @@ TESTING_SAMPLES_WITH_LAB_ID: List[Dict[str, Union[str, bool, ObjectId]]] = [
         FIELD_ROOT_SAMPLE_ID: "MCM001",
         FIELD_MONGODB_ID: ObjectId("aaaaaaaaaaaaaaaaaaaaaaa1"),
         FIELD_LAB_ID: "ALDP",
+        # This ch1_cq value is to test is not happening bug with mySql:
+        # mysql_connector.MySQLInterfaceError: Python type Decimal128 cannot be converted
+        FIELD_CH1_CQ: Decimal128("23.696882151458"),
     },
     {
         FIELD_COORDINATE: "A01",


### PR DESCRIPTION
(mysql_connector.MySQLInterfaceError: Python type Decimal128 cannot be converted)

Closes #

Changes proposed in this pull request:

*
*
* ...
