### PR TITLE
DPL-447-1: Augment logs and add retry for message deliveries

### DIFF
--- a/crawler/config/defaults.py
+++ b/crawler/config/defaults.py
@@ -86,6 +86,9 @@ RABBITMQ_VHOST = "heron"
 RABBITMQ_CRUD_QUEUE = "heron.crud-operations"
 RABBITMQ_FEEDBACK_EXCHANGE = "psd.heron"
 
+RABBITMQ_PUBLISH_RETRY_DELAY = 5
+RABBITMQ_PUBLISH_RETRIES = 36  # 3 minutes of retries
+
 ###
 # RedPanda details
 ###

--- a/crawler/config/development.py
+++ b/crawler/config/development.py
@@ -23,3 +23,6 @@ LOGGING["loggers"]["crawler"]["level"] = "DEBUG"
 LOGGING["loggers"]["crawler"]["handlers"] = ["colored_stream_dev"]
 LOGGING["loggers"]["apscheduler"]["level"] = "DEBUG"
 LOGGING["loggers"]["apscheduler"]["handlers"] = ["colored_stream_dev"]
+
+# Add colored_stream_dev to this list to see message bodies during development.
+LOGGING["loggers"]["rabbit_messages"]["handlers"] = []

--- a/crawler/config/logging.py
+++ b/crawler/config/logging.py
@@ -60,6 +60,11 @@ LOGGING: Dict[str, Any] = {
             "level": "INFO",
             "propagate": True,
         },
+        "rabbit_messages": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": True,
+        },
         "migrations": {
             "handlers": ["colored_stream"],
             "level": "DEBUG",

--- a/crawler/constants.py
+++ b/crawler/constants.py
@@ -8,6 +8,11 @@ from typing import Final, Set, Tuple
 SCHEDULER_JOB_ID_RUN_CRAWLER: Final[str] = "run_crawler"
 
 ###
+# Logger names
+###
+LOGGER_NAME_RABBIT_MESSAGES: Final[str] = "rabbit_messages"
+
+###
 # CentreConf dictionary keys
 ###
 CENTRE_KEY_BACKUPS_FOLDER: Final = "backups_folder"

--- a/crawler/processing/create_plate_exporter.py
+++ b/crawler/processing/create_plate_exporter.py
@@ -65,6 +65,8 @@ class CreatePlateExporter:
         self.__mongo_db = None
 
     def export_to_mongo(self):
+        LOGGER.debug("Starting export of create message to MongoDB.")
+
         with self._mongo_db.client.start_session() as session:
             with session.start_transaction():
                 source_plate_result = self._record_source_plate_in_mongo_db(session)
@@ -79,13 +81,23 @@ class CreatePlateExporter:
 
                 session.commit_transaction()
 
+        LOGGER.debug("Finished export of create message to MongoDB.")
+        self._message.log_error_count()
+
     def export_to_dart(self):
+        LOGGER.debug("Starting export of samples to DART.")
+
         result = self._record_samples_in_dart()
         if not result.success:
             for error in result.create_plate_errors:
                 self._message.add_error(error)
 
+        LOGGER.debug("Finished export of samples to DART.")
+        self._message.log_error_count()
+
     def record_import(self):
+        LOGGER.debug("Starting insert of import record to MongoDB.")
+
         plate_barcode = self._message.plate_barcode.value
         if not plate_barcode:
             # We don't record imports without a plate barcode available. They would be meaningless without the barcode.
@@ -107,6 +119,9 @@ class CreatePlateExporter:
             )
         except Exception as ex:
             LOGGER.exception(ex)
+
+        LOGGER.debug("Finished insert of import record to MongoDB.")
+        self._message.log_error_count()
 
     @property
     def _mongo_db(self):

--- a/crawler/processing/create_plate_processor.py
+++ b/crawler/processing/create_plate_processor.py
@@ -28,6 +28,8 @@ class CreatePlateProcessor(BaseProcessor):
         validator = CreatePlateValidator(create_message, self._config)
         exporter = CreatePlateExporter(create_message, self._config)
 
+        LOGGER.info(f"Starting processing of create message with UUID '{create_message.message_uuid}'")
+
         # First validate the message and then export the source plate and samples to MongoDB.
         try:
             validator.validate()
@@ -58,6 +60,9 @@ class CreatePlateProcessor(BaseProcessor):
         # message as processed since PAM cannot fix issues we had with DART export or recording the import.
         exporter.export_to_dart()
         exporter.record_import()
+
+        LOGGER.info(f"Finished processing of create message with UUID '{create_message.message_uuid}'")
+
         return True  # Acknowledge the message has been processed
 
     def _publish_feedback(self, create_message):

--- a/crawler/processing/create_plate_validator.py
+++ b/crawler/processing/create_plate_validator.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 from crawler.config.centres import CENTRE_DATA_SOURCE_RABBITMQ, get_centres_config
@@ -10,6 +11,8 @@ from crawler.exceptions import TransientRabbitError
 from crawler.helpers.sample_data_helpers import normalise_plate_coordinate
 from crawler.rabbit.messages.create_plate_message import CreatePlateError, ErrorType
 
+LOGGER = logging.getLogger(__name__)
+
 
 class CreatePlateValidator:
     def __init__(self, message, config):
@@ -19,9 +22,14 @@ class CreatePlateValidator:
         self._centres = None
 
     def validate(self):
+        LOGGER.debug("Starting validation of create message.")
+
         self._set_centre_conf()
         self._validate_plate()
         self._validate_samples()
+
+        LOGGER.debug("Validation finished.")
+        self._message.log_error_count()
 
     @property
     def centres(self):

--- a/crawler/processing/rabbit_message_processor.py
+++ b/crawler/processing/rabbit_message_processor.py
@@ -38,7 +38,7 @@ class RabbitMessageProcessor:
             message.decode(AvroEncoder(self._schema_registry, message.subject))
         except TransientRabbitError as ex:
             LOGGER.error(f"Transient error while processing message: {ex.message}")
-            raise  # Cause the consumer to restart and try this message again.  Ideally we will delay the consumer.
+            raise  # Cause the consumer to restart and try this message again.
         except Exception as ex:
             LOGGER.error(f"Unrecoverable error while decoding RabbitMQ message: {type(ex)} {str(ex)}")
             return False  # Send the message to dead letters.

--- a/crawler/processing/update_sample_exporter.py
+++ b/crawler/processing/update_sample_exporter.py
@@ -48,8 +48,13 @@ class UpdateSampleExporter:
 
         Raises a TransientRabbitError if Mongo is unreachable or cannot be queried.
         """
+        LOGGER.debug("Starting verification of sample state in MongoDB.")
+
         with self._mongo_db.client.start_session() as session:
             self._validate_mongo_properties(session)
+
+        LOGGER.debug("Finished verification of sample state in MongoDB.")
+        self._message.log_error_count()
 
     def verify_plate_state(self):
         """Verify that the plate has not already been picked by either Biosero or Beckman machines. If it has, a
@@ -59,7 +64,12 @@ class UpdateSampleExporter:
 
         Note:  This method will raise an exception if called before verify_sample_in_mongo().
         """
+        LOGGER.debug("Starting verification of plate state in Cherrytrack and DART.")
+
         self._verify_plate_not_in_cherrytrack() and self._verify_plate_state_in_dart()
+
+        LOGGER.debug("Finished verification of plate state in Cherrytrack and DART.")
+        self._message.log_error_count()
 
     def update_mongo(self):
         """Updates Mongo by replacing the document for the sample with a new one where the requested fields have been
@@ -69,8 +79,13 @@ class UpdateSampleExporter:
 
         Note:  This method will raise an exception if called before verify_sample_in_mongo().
         """
+        LOGGER.debug("Starting update of MongoDB with sample in update message.")
+
         with self._mongo_db.client.start_session() as session:
             self._update_sample_in_mongo(session)
+
+        LOGGER.debug("Finished updating MongoDB with sample in update message.")
+        self._message.log_error_count()
 
     def update_dart(self):
         """Update the DART database with the newly updated Mongo document. If any step of the update fails, a relevant
@@ -79,7 +94,12 @@ class UpdateSampleExporter:
         Note:  This method will raise an exception if called before verify_sample_in_mongo().
         """
         if not self._plate_missing_in_dart:
+            LOGGER.debug("Starting update of DART records for sample in update message.")
+
             self._update_sample_in_dart()
+
+            LOGGER.debug("Finished update of DART records for sample in update message.")
+            self._message.log_error_count()
 
     @property
     def _mongo_db(self):

--- a/crawler/processing/update_sample_processor.py
+++ b/crawler/processing/update_sample_processor.py
@@ -28,6 +28,8 @@ class UpdateSampleProcessor(BaseProcessor):
         validator = UpdateSampleValidator(update_message)
         exporter = UpdateSampleExporter(update_message, self._config)
 
+        LOGGER.info(f"Starting processing of update message with UUID '{update_message.message_uuid}'")
+
         # First validate the message and then export the updates to MongoDB.
         try:
             validator.validate()
@@ -57,6 +59,8 @@ class UpdateSampleProcessor(BaseProcessor):
             return False  # Errors up to this point mean we should send the message to dead-letters.
 
         exporter.update_dart()
+
+        LOGGER.info(f"Finished processing of update message with UUID '{update_message.message_uuid}'")
 
         return True  # The message has been processed whether DART worked or not.
 

--- a/crawler/processing/update_sample_validator.py
+++ b/crawler/processing/update_sample_validator.py
@@ -1,6 +1,10 @@
+import logging
+
 from crawler.constants import RABBITMQ_UPDATE_FEEDBACK_ORIGIN_FIELD
 from crawler.helpers.general_helpers import extract_duplicated_values
 from crawler.rabbit.messages.update_sample_message import ErrorType, UpdateSampleError
+
+LOGGER = logging.getLogger(__name__)
 
 
 class UpdateSampleValidator:
@@ -8,7 +12,12 @@ class UpdateSampleValidator:
         self._message = message
 
     def validate(self):
+        LOGGER.debug("Starting validation of update message.")
+
         self._validate_updated_fields()
+
+        LOGGER.debug("Validation finished.")
+        self._message.log_error_count()
 
     def _validate_updated_fields(self):
         """Perform validation that updated fields are populated and only contain each possible field once at most."""

--- a/crawler/rabbit/async_consumer.py
+++ b/crawler/rabbit/async_consumer.py
@@ -11,9 +11,11 @@ from pika.adapters.utils.connection_workflow import (
 )
 from pika.exceptions import AMQPConnectionError
 
+from crawler.constants import LOGGER_NAME_RABBIT_MESSAGES
 from crawler.exceptions import TransientRabbitError
 
 LOGGER = logging.getLogger(__name__)
+MESSAGE_LOGGER = logging.getLogger(LOGGER_NAME_RABBIT_MESSAGES)
 
 
 class AsyncConsumer(object):
@@ -265,7 +267,8 @@ class AsyncConsumer(object):
         :param pika.Spec.BasicProperties: properties
         :param bytes body: The message body
         """
-        LOGGER.info("Received message # %s from %s", basic_deliver.delivery_tag, properties.app_id)
+        LOGGER.info(f"Received message # {basic_deliver.delivery_tag}")
+        MESSAGE_LOGGER.info(f"Received message # {basic_deliver.delivery_tag} with body:  {body.decode()}")
         delivery_tag = basic_deliver.delivery_tag
 
         try:
@@ -275,10 +278,10 @@ class AsyncConsumer(object):
             raise
 
         if should_ack_message:
-            LOGGER.info("Acknowledging message %s", delivery_tag)
+            LOGGER.info("Acknowledging message # %s", delivery_tag)
             channel.basic_ack(delivery_tag)
         else:
-            LOGGER.info("Rejecting message %s", delivery_tag)
+            LOGGER.info("Rejecting message # %s", delivery_tag)
             channel.basic_nack(delivery_tag, requeue=False)
 
     def stop_consuming(self):

--- a/crawler/rabbit/avro_encoder.py
+++ b/crawler/rabbit/avro_encoder.py
@@ -34,7 +34,7 @@ class AvroEncoder:
         return schema_response[RESPONSE_KEY_VERSION]
 
     def encode(self, records: List, version: str = None) -> EncodedMessage:
-        LOGGER.debug(f"Encoding AVRO message.")
+        LOGGER.debug("Encoding AVRO message.")
 
         schema_response = self._schema_response(version)
         string_writer = StringIO()
@@ -45,7 +45,7 @@ class AvroEncoder:
         )
 
     def decode(self, message: bytes, version: str) -> Any:
-        LOGGER.debug(f"Decoding AVRO message.")
+        LOGGER.debug("Decoding AVRO message.")
 
         schema_response = self._schema_response(version)
         string_reader = StringIO(message.decode("utf-8"))

--- a/crawler/rabbit/avro_encoder.py
+++ b/crawler/rabbit/avro_encoder.py
@@ -1,10 +1,13 @@
 import json
+import logging
 from io import StringIO
 from typing import Any, List, NamedTuple
 
 import fastavro
 
 from crawler.rabbit.schema_registry import RESPONSE_KEY_SCHEMA, RESPONSE_KEY_VERSION
+
+LOGGER = logging.getLogger(__name__)
 
 
 class EncodedMessage(NamedTuple):
@@ -31,6 +34,8 @@ class AvroEncoder:
         return schema_response[RESPONSE_KEY_VERSION]
 
     def encode(self, records: List, version: str = None) -> EncodedMessage:
+        LOGGER.debug(f"Encoding AVRO message.")
+
         schema_response = self._schema_response(version)
         string_writer = StringIO()
         fastavro.json_writer(string_writer, self._schema(schema_response), records)
@@ -40,6 +45,8 @@ class AvroEncoder:
         )
 
     def decode(self, message: bytes, version: str) -> Any:
+        LOGGER.debug(f"Decoding AVRO message.")
+
         schema_response = self._schema_response(version)
         string_reader = StringIO(message.decode("utf-8"))
 

--- a/crawler/rabbit/basic_publisher.py
+++ b/crawler/rabbit/basic_publisher.py
@@ -74,5 +74,5 @@ class BasicPublisher:
 
         if retry_count > 0:
             LOGGER.error(f"Publish of message to RabbitMQ required {retry_count} retries.")
-        else:
-            LOGGER.info("The message was published to RabbitMQ successfully.")
+
+        LOGGER.info("The message was published to RabbitMQ successfully.")

--- a/crawler/rabbit/basic_publisher.py
+++ b/crawler/rabbit/basic_publisher.py
@@ -8,6 +8,7 @@ from pika.spec import PERSISTENT_DELIVERY_MODE
 from crawler.constants import LOGGER_NAME_RABBIT_MESSAGES, RABBITMQ_HEADER_KEY_SUBJECT, RABBITMQ_HEADER_KEY_VERSION
 from crawler.types import RabbitServerDetails
 
+LOGGER = logging.getLogger(__name__)
 MESSAGE_LOGGER = logging.getLogger(LOGGER_NAME_RABBIT_MESSAGES)
 
 
@@ -27,7 +28,7 @@ class BasicPublisher:
             self._connection_params.ssl_options = SSLOptions(ssl_context)
 
     def publish_message(self, exchange, routing_key, body, subject, schema_version):
-        MESSAGE_LOGGER.info(
+        LOGGER.info(
             f"Publishing message to exchange '{exchange}', routing key '{routing_key}', "
             f"schema subject '{subject}', schema version '{schema_version}'."
         )

--- a/crawler/rabbit/basic_publisher.py
+++ b/crawler/rabbit/basic_publisher.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import ssl
+import time
 
 from pika import BasicProperties, BlockingConnection, ConnectionParameters, PlainCredentials, SSLOptions
+from pika.exceptions import UnroutableError
 from pika.spec import PERSISTENT_DELIVERY_MODE
 
 from crawler.constants import LOGGER_NAME_RABBIT_MESSAGES, RABBITMQ_HEADER_KEY_SUBJECT, RABBITMQ_HEADER_KEY_VERSION
@@ -13,7 +15,9 @@ MESSAGE_LOGGER = logging.getLogger(LOGGER_NAME_RABBIT_MESSAGES)
 
 
 class BasicPublisher:
-    def __init__(self, server_details: RabbitServerDetails):
+    def __init__(self, server_details: RabbitServerDetails, publish_retry_delay: int, publish_max_retries: int):
+        self._publish_retry_delay = publish_retry_delay
+        self._publish_max_retries = publish_max_retries
         credentials = PlainCredentials(server_details.username, server_details.password)
         self._connection_params = ConnectionParameters(
             host=server_details.host,
@@ -43,10 +47,32 @@ class BasicPublisher:
 
         connection = BlockingConnection(self._connection_params)
         channel = connection.channel()
-        channel.basic_publish(
-            exchange=exchange,
-            routing_key=routing_key,
-            properties=properties,
-            body=body,
+        channel.confirm_delivery()  # Force exceptions when Rabbit cannot deliver the message
+        self._do_publish_with_retry(
+            lambda: channel.basic_publish(exchange=exchange, routing_key=routing_key, body=body, properties=properties)
         )
         connection.close()
+
+    def _do_publish_with_retry(self, publish_method):
+        retry_count = 0
+
+        while True:
+            try:
+                publish_method()
+                break  # When no exception is thrown from publish_method we'll break out of the while loop
+            except UnroutableError:
+                retry_count += 1
+
+                if retry_count == self._publish_max_retries:
+                    LOGGER.error(
+                        "Maximum number of retries exceeded for message being published to RabbitMQ. "
+                        "Message was NOT PUBLISHED!"
+                    )
+                    return
+
+                time.sleep(self._publish_retry_delay)
+
+        if retry_count > 0:
+            LOGGER.error(f"Publish of message to RabbitMQ required {retry_count} retries.")
+        else:
+            LOGGER.info("The message was published to RabbitMQ successfully.")

--- a/crawler/rabbit/basic_publisher.py
+++ b/crawler/rabbit/basic_publisher.py
@@ -1,11 +1,14 @@
+import logging
 import os
 import ssl
 
 from pika import BasicProperties, BlockingConnection, ConnectionParameters, PlainCredentials, SSLOptions
 from pika.spec import PERSISTENT_DELIVERY_MODE
 
-from crawler.constants import RABBITMQ_HEADER_KEY_SUBJECT, RABBITMQ_HEADER_KEY_VERSION
+from crawler.constants import LOGGER_NAME_RABBIT_MESSAGES, RABBITMQ_HEADER_KEY_SUBJECT, RABBITMQ_HEADER_KEY_VERSION
 from crawler.types import RabbitServerDetails
+
+MESSAGE_LOGGER = logging.getLogger(LOGGER_NAME_RABBIT_MESSAGES)
 
 
 class BasicPublisher:
@@ -24,6 +27,11 @@ class BasicPublisher:
             self._connection_params.ssl_options = SSLOptions(ssl_context)
 
     def publish_message(self, exchange, routing_key, body, subject, schema_version):
+        MESSAGE_LOGGER.info(
+            f"Publishing message to exchange '{exchange}', routing key '{routing_key}', "
+            f"schema subject '{subject}', schema version '{schema_version}'."
+        )
+        MESSAGE_LOGGER.info(f"Published message body:  {body.decode()}")
         properties = BasicProperties(
             delivery_mode=PERSISTENT_DELIVERY_MODE,
             headers={

--- a/crawler/rabbit/messages/base_message.py
+++ b/crawler/rabbit/messages/base_message.py
@@ -1,3 +1,8 @@
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
 class BaseMessage:
     def __init__(self):
         self._textual_errors = []
@@ -21,3 +26,6 @@ class BaseMessage:
 
     def add_textual_error(self, description):
         self._textual_errors.append(description)
+
+    def log_error_count(self):
+        LOGGER.debug(f"Number of errors recorded on message: {len(self._textual_errors)}.")

--- a/crawler/rabbit/rabbit_stack.py
+++ b/crawler/rabbit/rabbit_stack.py
@@ -35,7 +35,11 @@ class RabbitStack:
         return SchemaRegistry(redpanda_url, redpanda_api_key)
 
     def _rabbit_message_processor(self):
-        basic_publisher = BasicPublisher(self._rabbit_server_details())
+        basic_publisher = BasicPublisher(
+            self._rabbit_server_details(),
+            self._config.RABBITMQ_PUBLISH_RETRY_DELAY,
+            self._config.RABBITMQ_PUBLISH_RETRIES,
+        )
         return RabbitMessageProcessor(self._schema_registry(), basic_publisher, self._config)
 
     def bring_stack_up(self):

--- a/crawler/rabbit/schema_registry.py
+++ b/crawler/rabbit/schema_registry.py
@@ -1,3 +1,4 @@
+import logging
 from functools import lru_cache
 
 from requests import get
@@ -6,6 +7,8 @@ from crawler.exceptions import TransientRabbitError
 
 RESPONSE_KEY_VERSION = "version"
 RESPONSE_KEY_SCHEMA = "schema"
+
+LOGGER = logging.getLogger(__name__)
 
 
 @lru_cache
@@ -22,4 +25,7 @@ class SchemaRegistry:
         self._api_key = api_key
 
     def get_schema(self, subject: str, version: str = "latest") -> dict:
-        return get_json_from_url(f"{self._base_uri}/subjects/{subject}/versions/{version}", self._api_key)
+        schema_url = f"{self._base_uri}/subjects/{subject}/versions/{version}"
+        LOGGER.debug(f"Getting schema from registry at {schema_url}.")
+
+        return get_json_from_url(schema_url, self._api_key)

--- a/crawler/types.py
+++ b/crawler/types.py
@@ -90,6 +90,9 @@ class Config(ModuleType):
     RABBITMQ_CRUD_QUEUE: str
     RABBITMQ_FEEDBACK_EXCHANGE: str
 
+    RABBITMQ_PUBLISH_RETRY_DELAY: int
+    RABBITMQ_PUBLISH_RETRIES: int
+
     # RedPanda
     REDPANDA_BASE_URI: str
     REDPANDA_API_KEY: str

--- a/tests/processing/test_create_plate_exporter.py
+++ b/tests/processing/test_create_plate_exporter.py
@@ -332,8 +332,8 @@ def test_export_to_dart_creates_no_message_errors(subject, pyodbc_conn, logger):
 
     assert subject._message.has_errors is False
 
-    logger.debug.assert_called_once()
-    assert "DART database inserts completed successfully" in logger.debug.call_args.args[0]
+    assert logger.debug.call_count == 3
+    assert "DART database inserts completed successfully" in logger.debug.call_args_list[1].args[0]
 
 
 @pytest.mark.parametrize("plate_state", [DART_STATE_NO_PLATE, DART_STATE_NO_PROP, DART_STATE_PICKABLE])

--- a/tests/rabbit/messages/test_base_message.py
+++ b/tests/rabbit/messages/test_base_message.py
@@ -1,6 +1,14 @@
+from unittest.mock import patch
+
 import pytest
 
 from crawler.rabbit.messages.base_message import BaseMessage
+
+
+@pytest.fixture
+def logger():
+    with patch("crawler.rabbit.messages.base_message.LOGGER") as logger:
+        yield logger
 
 
 @pytest.fixture
@@ -34,3 +42,17 @@ def test_textual_errors_summary_is_accurate_for_6_errors(subject):
         "Error 4",
         "Error 5",
     ]
+
+
+@pytest.mark.parametrize(
+    "textual_errors, error_count",
+    [[[], 0], [["Error 1"], 1], [["Error 1", "Error 2"], 2], [["Error 1", "Error 2", "Error 3"], 3]],
+)
+def test_log_error_count_logs_error_count_correctly(subject, logger, textual_errors, error_count):
+    subject._textual_errors = textual_errors
+
+    subject.log_error_count()
+
+    logger.debug.assert_called_once()
+    log_message = logger.debug.call_args.args[0]
+    assert str(error_count) in log_message

--- a/tests/rabbit/test_async_consumer.py
+++ b/tests/rabbit/test_async_consumer.py
@@ -12,9 +12,15 @@ DEFAULT_SERVER_DETAILS = RabbitServerDetails(
 
 
 @pytest.fixture
-def mock_logger():
+def logger():
     with patch("crawler.rabbit.async_consumer.LOGGER") as logger:
         yield logger
+
+
+@pytest.fixture
+def message_logger():
+    with patch("crawler.rabbit.async_consumer.MESSAGE_LOGGER") as message_logger:
+        yield message_logger
 
 
 @pytest.fixture
@@ -23,7 +29,7 @@ def subject():
 
 
 @pytest.mark.parametrize("uses_ssl", [True, False])
-def test_connect_provides_correct_parameters(mock_logger, uses_ssl):
+def test_connect_provides_correct_parameters(logger, uses_ssl):
     server_details = RabbitServerDetails(
         uses_ssl=uses_ssl, host="host", port=5672, username="username", password="password", vhost="vhost"
     )
@@ -42,42 +48,42 @@ def test_connect_provides_correct_parameters(mock_logger, uses_ssl):
     assert parameters.credentials.username == server_details.username
     assert parameters.credentials.password == server_details.password
     assert parameters.virtual_host == server_details.vhost
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
 
 
-def test_close_connection_sets_consuming_false(subject, mock_logger):
+def test_close_connection_sets_consuming_false(subject, logger):
     subject._consuming = True
     subject.close_connection()
 
     assert subject._consuming is False
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
 
 
-def test_close_connection_calls_close_on_connection(subject, mock_logger):
+def test_close_connection_calls_close_on_connection(subject, logger):
     subject._connection = MagicMock()
     subject._connection.is_closing = False
     subject._connection.is_closed = False
     subject.close_connection()
 
     subject._connection.close.assert_called_once()
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
 
 
-def test_on_connection_open_calls_open_channel(subject, mock_logger):
+def test_on_connection_open_calls_open_channel(subject, logger):
     with patch("crawler.rabbit.async_consumer.AsyncConsumer.open_channel") as open_channel:
         subject.on_connection_open(Mock())
 
     open_channel.assert_called_once()
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
 
 
-def test_on_connection_open_error_calls_reconnect(subject, mock_logger):
+def test_on_connection_open_error_calls_reconnect(subject, logger):
     error = Exception("An error")
     with patch("crawler.rabbit.async_consumer.AsyncConsumer.reconnect") as reconnect:
         subject.on_connection_open_error(Mock(), error)
 
     reconnect.assert_called_once()
-    mock_logger.error.assert_called_once_with(ANY, error)
+    logger.error.assert_called_once_with(ANY, error)
 
 
 def test_on_connection_closed_sets_channel_to_none(subject):
@@ -96,7 +102,7 @@ def test_on_connection_closed_stops_the_ioloop(subject):
     subject._connection.ioloop.stop.assert_called_once()
 
 
-def test_on_connection_closed_reconnects_when_not_in_closing_state(subject, mock_logger):
+def test_on_connection_closed_reconnects_when_not_in_closing_state(subject, logger):
     subject._connection = MagicMock()
     subject._closing = False
     reason = "A reason"
@@ -104,7 +110,7 @@ def test_on_connection_closed_reconnects_when_not_in_closing_state(subject, mock
         subject.on_connection_closed(Mock(), reason)
 
     reconnect.assert_called_once()
-    mock_logger.warning.assert_called_once_with(ANY, reason)
+    logger.warning.assert_called_once_with(ANY, reason)
 
 
 def test_reconnect_prepares_for_reconnection(subject):
@@ -116,57 +122,57 @@ def test_reconnect_prepares_for_reconnection(subject):
     stop.assert_called_once()
 
 
-def test_open_channel_calls_the_connection_method(subject, mock_logger):
+def test_open_channel_calls_the_connection_method(subject, logger):
     subject._connection = MagicMock()
     subject.open_channel()
 
     subject._connection.channel.assert_called_once()
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
 
 
-def test_open_channel_logs_when_no_connection(subject, mock_logger):
+def test_open_channel_logs_when_no_connection(subject, logger):
     subject._connection = None
     subject.open_channel()
 
-    mock_logger.error.assert_called_once()
+    logger.error.assert_called_once()
 
 
-def test_on_channel_open_sets_the_channel_and_calls_follow_up_methods(subject, mock_logger):
+def test_on_channel_open_sets_the_channel_and_calls_follow_up_methods(subject, logger):
     subject._channel = None
     fake_channel = Mock()
     with patch("crawler.rabbit.async_consumer.AsyncConsumer.add_on_channel_close_callback") as add_callback:
         with patch("crawler.rabbit.async_consumer.AsyncConsumer.set_qos") as set_qos:
             subject.on_channel_open(fake_channel)
 
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
     assert subject._channel == fake_channel
     add_callback.assert_called_once()
     set_qos.assert_called_once()
 
 
-def test_add_on_channel_close_callback_calls_the_channel_method(subject, mock_logger):
+def test_add_on_channel_close_callback_calls_the_channel_method(subject, logger):
     subject._channel = MagicMock()
     subject.add_on_channel_close_callback()
 
     subject._channel.add_on_close_callback.assert_called_once()
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
 
 
-def test_add_on_channel_close_callback_logs_when_no_channel(subject, mock_logger):
+def test_add_on_channel_close_callback_logs_when_no_channel(subject, logger):
     subject._channel = None
     subject.add_on_channel_close_callback()
 
-    mock_logger.error.assert_called_once()
+    logger.error.assert_called_once()
 
 
-def test_on_channel_closed_calls_close_connection(subject, mock_logger):
+def test_on_channel_closed_calls_close_connection(subject, logger):
     channel = "A channel"
     reason = "A reason"
     with patch("crawler.rabbit.async_consumer.AsyncConsumer.close_connection") as close_connection:
         subject.on_channel_closed(channel, reason)
 
     close_connection.assert_called_once()
-    mock_logger.warning.assert_called_once_with(ANY, channel, reason)
+    logger.warning.assert_called_once_with(ANY, channel, reason)
 
 
 @pytest.mark.parametrize("prefetch_count", [1, 5, 10])
@@ -179,23 +185,23 @@ def test_set_qos_applies_prefetch_count_to_channel(subject, prefetch_count):
 
 
 @pytest.mark.parametrize("prefetch_count", [1, 5, 10])
-def test_on_basic_qos_ok_calls_start_consuming(subject, mock_logger, prefetch_count):
+def test_on_basic_qos_ok_calls_start_consuming(subject, logger, prefetch_count):
     subject._prefetch_count = prefetch_count
     with patch("crawler.rabbit.async_consumer.AsyncConsumer.start_consuming") as start_consuming:
         subject.on_basic_qos_ok(Mock())
 
     start_consuming.assert_called_once()
-    mock_logger.info.assert_called_once_with(ANY, prefetch_count)
+    logger.info.assert_called_once_with(ANY, prefetch_count)
 
 
-def test_start_consuming_logs_when_no_channel(subject, mock_logger):
+def test_start_consuming_logs_when_no_channel(subject, logger):
     subject._channel = None
     subject.start_consuming()
 
-    mock_logger.error.assert_called_once()
+    logger.error.assert_called_once()
 
 
-def test_start_consuming_takes_necessary_actions(subject, mock_logger):
+def test_start_consuming_takes_necessary_actions(subject, logger):
     # Test objects
     test_tag = "Test tag"
     test_queue = "queue.name"
@@ -213,7 +219,7 @@ def test_start_consuming_takes_necessary_actions(subject, mock_logger):
         subject.start_consuming()
 
     # Assert
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
     add_callback.assert_called_once()
     subject._channel.basic_consume.assert_called_once_with(test_queue, ANY)
     assert subject._consumer_tag == test_tag
@@ -221,29 +227,29 @@ def test_start_consuming_takes_necessary_actions(subject, mock_logger):
     assert subject._consuming is True
 
 
-def test_add_on_cancel_callback_calls_the_channel_method(subject, mock_logger):
+def test_add_on_cancel_callback_calls_the_channel_method(subject, logger):
     subject._channel = MagicMock()
     subject.add_on_cancel_callback()
 
     subject._channel.add_on_cancel_callback.assert_called_once()
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
 
 
-def test_add_on_cancel_callback_logs_when_no_channel(subject, mock_logger):
+def test_add_on_cancel_callback_logs_when_no_channel(subject, logger):
     subject._channel = None
     subject.add_on_cancel_callback()
 
-    mock_logger.error.assert_called_once()
+    logger.error.assert_called_once()
 
 
-def test_on_consumer_cancelled_logs(subject, mock_logger):
+def test_on_consumer_cancelled_logs(subject, logger):
     method_frame = Mock()
     subject.on_consumer_cancelled(method_frame)
 
-    mock_logger.info.assert_called_once_with(ANY, method_frame)
+    logger.info.assert_called_once_with(ANY, method_frame)
 
 
-def test_on_consumer_cancelled_calls_channel_close(subject, mock_logger):
+def test_on_consumer_cancelled_calls_channel_close(subject, logger):
     subject._channel = MagicMock()
     subject.on_consumer_cancelled(Mock())
 
@@ -254,7 +260,9 @@ def test_on_consumer_cancelled_calls_channel_close(subject, mock_logger):
     "return_value,ack_calls,nack_calls",
     [[False, [], [call("Test tag", requeue=False)]], [True, [call("Test tag")], []]],
 )
-def test_on_message_passes_relevant_info_to_process_message(subject, mock_logger, return_value, ack_calls, nack_calls):
+def test_on_message_passes_relevant_info_to_process_message(
+    subject, logger, message_logger, return_value, ack_calls, nack_calls
+):
     subject._process_message = Mock(return_value=return_value)
 
     # Arrange arguments
@@ -276,7 +284,10 @@ def test_on_message_passes_relevant_info_to_process_message(subject, mock_logger
     subject.on_message(channel, basic_deliver, properties, body)
 
     # Assert
-    assert mock_logger.info.call_count == 2
+    assert logger.info.call_count == 2
+    message_logger.info.assert_called_once()
+    assert body.decode() in message_logger.info.call_args.args[0]
+
     subject._process_message.assert_called_once_with(headers, body)
 
     channel.basic_ack.assert_has_calls(ack_calls)
@@ -297,16 +308,16 @@ def test_on_message_handles_transient_rabbit_error(subject):
     assert subject.had_transient_error is True
 
 
-def test_stop_consuming_calls_the_channel_method(subject, mock_logger):
+def test_stop_consuming_calls_the_channel_method(subject, logger):
     subject._channel = MagicMock()
     subject._consumer_tag = Mock()
     subject.stop_consuming()
 
     subject._channel.basic_cancel.assert_called_once_with(subject._consumer_tag, ANY)
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
 
 
-def test_on_cancelok_calls_close_channel_method(subject, mock_logger):
+def test_on_cancelok_calls_close_channel_method(subject, logger):
     subject._channel = MagicMock()
     subject._consuming = True
     userdata = Mock()
@@ -315,23 +326,23 @@ def test_on_cancelok_calls_close_channel_method(subject, mock_logger):
         subject.on_cancelok(Mock(), userdata)
 
     assert subject._consuming is False
-    mock_logger.info.assert_called_once_with(ANY, userdata)
+    logger.info.assert_called_once_with(ANY, userdata)
     close_channel.assert_called_once()
 
 
-def test_close_channel_calls_the_channel_method(subject, mock_logger):
+def test_close_channel_calls_the_channel_method(subject, logger):
     subject._channel = MagicMock()
     subject.close_channel()
 
     subject._channel.close.assert_called_once()
-    mock_logger.info.assert_called_once()
+    logger.info.assert_called_once()
 
 
-def test_close_channel_logs_when_no_channel(subject, mock_logger):
+def test_close_channel_logs_when_no_channel(subject, logger):
     subject._channel = None
     subject.close_channel()
 
-    mock_logger.error.assert_called_once()
+    logger.error.assert_called_once()
 
 
 def test_run_starts_the_ioloop_when_connection_created(subject):
@@ -344,20 +355,20 @@ def test_run_starts_the_ioloop_when_connection_created(subject):
     test_connection.ioloop.start.assert_called_once()
 
 
-def test_run_logs_error_when_connection_not_created(subject, mock_logger):
+def test_run_logs_error_when_connection_not_created(subject, logger):
     subject._connection = None
     with patch("crawler.rabbit.async_consumer.AsyncConsumer.connect", return_value=None):
         subject.run()
 
-    mock_logger.error.assert_called_once()
+    logger.error.assert_called_once()
 
 
-def test_stop_logs_process(subject, mock_logger):
+def test_stop_logs_process(subject, logger):
     subject._closing = False
     with patch("crawler.rabbit.async_consumer.AsyncConsumer.stop_consuming"):
         subject.stop()
 
-    mock_logger.info.assert_has_calls([call("Stopping"), call("Stopped")])
+    logger.info.assert_has_calls([call("Stopping"), call("Stopped")])
 
 
 def test_stop_takes_correct_actions_when_consuming(subject):
@@ -384,10 +395,10 @@ def test_stop_takes_correct_actions_when_not_consuming(subject):
     subject._connection.ioloop.start.assert_not_called()
 
 
-def test_stop_does_nothing_if_already_closing(subject, mock_logger):
+def test_stop_does_nothing_if_already_closing(subject, logger):
     subject._closing = True
     with patch("crawler.rabbit.async_consumer.AsyncConsumer.stop_consuming") as stop_consuming:
         subject.stop()
 
     stop_consuming.assert_not_called()
-    mock_logger.info.assert_not_called()
+    logger.info.assert_not_called()

--- a/tests/rabbit/test_async_consumer.py
+++ b/tests/rabbit/test_async_consumer.py
@@ -270,13 +270,13 @@ def test_on_message_passes_relevant_info_to_process_message(subject, mock_logger
     properties.app_id = app_id
     properties.headers = headers
 
-    body = "A message body"
+    body = "A message body".encode()
 
     # Act
     subject.on_message(channel, basic_deliver, properties, body)
 
     # Assert
-    mock_logger.info.assert_has_calls([call(ANY, delivery_tag, app_id), call(ANY, delivery_tag)])
+    assert mock_logger.info.call_count == 2
     subject._process_message.assert_called_once_with(headers, body)
 
     channel.basic_ack.assert_has_calls(ack_calls)
@@ -290,7 +290,7 @@ def test_on_message_handles_transient_rabbit_error(subject):
     assert subject.had_transient_error is False
 
     with pytest.raises(TransientRabbitError):
-        subject.on_message(channel, MagicMock(), MagicMock(), "")
+        subject.on_message(channel, MagicMock(), MagicMock(), "".encode())
 
     channel.basic_ack.assert_not_called()
     channel.basic_nack.assert_not_called()

--- a/tests/rabbit/test_basic_publisher.py
+++ b/tests/rabbit/test_basic_publisher.py
@@ -93,8 +93,10 @@ def test_publish_message_publishes_the_message(
 
 @pytest.mark.parametrize("error_count", [1, 2, 3, 4])
 def test_publish_message_retries_when_needed(subject, channel, logger, error_count):
-    unroutable_error = pika.exceptions.UnroutableError(["Boom!"])
-    channel.basic_publish.side_effect = [unroutable_error] * error_count + [None]
+    unroutable_error = pika.exceptions.UnroutableError([])
+    side_effects: list = [unroutable_error] * error_count
+    side_effects.append(None)
+    channel.basic_publish.side_effect = side_effects
 
     subject.publish_message("exchange", "routing_key", "body".encode(), "schema_subject", "schema_version")
 
@@ -107,8 +109,10 @@ def test_publish_message_retries_when_needed(subject, channel, logger, error_cou
 
 @pytest.mark.parametrize("error_count", [5, 10, 100])
 def test_publish_message_stops_retrying_after_max_retries(subject, channel, logger, error_count):
-    unroutable_error = pika.exceptions.UnroutableError(["Boom!"])
-    channel.basic_publish.side_effect = [unroutable_error] * error_count + [None]
+    unroutable_error = pika.exceptions.UnroutableError([])
+    side_effects: list = [unroutable_error] * error_count
+    side_effects.append(None)
+    channel.basic_publish.side_effect = side_effects
 
     subject.publish_message("exchange", "routing_key", "body".encode(), "schema_subject", "schema_version")
 

--- a/tests/rabbit/test_basic_publisher.py
+++ b/tests/rabbit/test_basic_publisher.py
@@ -60,7 +60,7 @@ def test_constructor_creates_correct_connection_parameters(uses_ssl, host, port,
 
 @pytest.mark.parametrize("exchange", ["", "exchange"])
 @pytest.mark.parametrize("routing_key", ["", "routing_key"])
-@pytest.mark.parametrize("body", ["", "body"])
+@pytest.mark.parametrize("body", ["".encode(), "body".encode()])
 @pytest.mark.parametrize("schema_subject", ["", "subject"])
 @pytest.mark.parametrize("schema_version", ["", "schema_version"])
 def test_publish_message_publishes_the_message(


### PR DESCRIPTION
Closes #633 

Changes proposed in this pull request:

* Add logging of message bodies going in and out of RabbitMQ.
* Make Crawler try multiple times if it cannot get a feedback message on the Rabbit queue.
    * If multiple tries are needed, report an error.
    * If the max number of tries are exceeded, report an error stating that the feedback was never sent.
* Log more debug statements monitoring the flow of data through the Rabbit processors.