### PR TITLE
DPL-480: Make sure fitToPick is only true is the sample has a positive result

### DIFF
--- a/crawler/helpers/cherrypicker_test_data.py
+++ b/crawler/helpers/cherrypicker_test_data.py
@@ -132,7 +132,7 @@ def _create_sample(dt: datetime, index: int, result: str, plate_barcode: str) ->
         plateCoordinate=well_coordinate,
         preferentiallySequence=False,
         mustSequence=False,
-        fitToPick=True,
+        fitToPick=True if result == "positive" else False,
         result=result,
         testedDateUtc=dt,
     )

--- a/tests/helpers/test_cherrypicker_data_helper.py
+++ b/tests/helpers/test_cherrypicker_data_helper.py
@@ -225,7 +225,7 @@ def test_create_plate_messages():
             assert sample["plateCoordinate"] == WELL_COORDS[sample_i]
             assert sample["preferentiallySequence"] is False
             assert sample["mustSequence"] is False
-            assert sample["fitToPick"] is True
+            assert sample["fitToPick"] is (True if sample["result"] == "positive" else False)
             assert sample["testedDateUtc"] == dt
 
         # Check the correct number of positives exist among all the samples


### PR DESCRIPTION
Closes #661 

Changes proposed in this pull request:

* Make negative samples generated for test data have `fit_to_pick` set to `False` instead of `True`
