### PR TITLE
Fix GitHub action builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use alpine for a smaller image size and install only the required packages
-FROM python:3.8-slim-buster
+# Use bullseye for a smaller image size and install only the required packages
+FROM python:3.10-slim-bullseye
 
 # > Setting PYTHONUNBUFFERED to a non empty value ensures that the python output is sent straight to
 # > terminal (e.g. your container log) without being first buffered and that you can see the output


### PR DESCRIPTION
I had intended this to be to find the fix for the GitHub build but it has self resolved by `pipenv` backing out a controversial change they released in the 2022-10-10 version.  However I felt the change in this PR is probably worthwhile as well so I'm leaving it here for review.

This updates the base image used by Docker to the latest released version and updates the out of date comment above it.
